### PR TITLE
feat: output help if no argument is given

### DIFF
--- a/src/bin/ambit/main.rs
+++ b/src/bin/ambit/main.rs
@@ -1,6 +1,6 @@
 mod directories;
 
-use clap::{App, Arg, SubCommand};
+use clap::{App, AppSettings, Arg, SubCommand};
 
 use std::process;
 
@@ -97,6 +97,7 @@ fn run() -> AmbitResult<()> {
 
     let matches = App::new("ambit")
         .about("Dotfile manager")
+        .setting(AppSettings::ArgRequiredElseHelp)
         .subcommand(
             SubCommand::with_name("init")
                 .about("Initialize an empty dotfile repository")


### PR DESCRIPTION
I doubt `ambit` will provide functionality when no arguments are passed. This PR will invoke the help message to be printed if a user doesn't provide any arguments.

e.g.
```
$ ambit
```