### PR TITLE
refactor(config): change ParseError to encapsulate both token and ParseErrorType

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,6 +15,7 @@ pub enum ParseErrorType {
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ParseError {
     pub ty: ParseErrorType,
+    // Some(_) if it failed at a token, or None if it failed at EOF.
     pub tok: Option<lexer::Token>,
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,15 +15,12 @@ pub enum ParseErrorType {
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ParseError {
     pub ty: ParseErrorType,
-    pub tok: Option<lexer::Token>
+    pub tok: Option<lexer::Token>,
 }
 
 impl From<ParseErrorType> for ParseError {
     fn from(ty: ParseErrorType) -> Self {
-        Self {
-            ty,
-            tok: None
-        }
+        Self { ty, tok: None }
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,12 +7,27 @@ pub use parser::{Entry, Parser};
 use std::iter::Peekable;
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
-pub enum ParseError {
+pub enum ParseErrorType {
     Expected(&'static [lexer::TokType]),
     Custom(&'static str),
 }
 
-pub type ParseResult<T> = std::result::Result<T, (Option<lexer::Token>, ParseError)>;
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct ParseError {
+    pub ty: ParseErrorType,
+    pub tok: Option<lexer::Token>
+}
+
+impl From<ParseErrorType> for ParseError {
+    fn from(ty: ParseErrorType) -> Self {
+        Self {
+            ty,
+            tok: None
+        }
+    }
+}
+
+pub type ParseResult<T> = std::result::Result<T, ParseError>;
 
 pub fn get_entries<I: Iterator<Item = char>>(char_iter: Peekable<I>) -> Parser<Lexer<I>> {
     let lex = Lexer::new(char_iter);

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -1,4 +1,4 @@
-use crate::config::{lexer::*, ParseError, ParseResult};
+use crate::config::{lexer::*, ParseError, ParseErrorType, ParseResult};
 
 use std::iter::Peekable;
 
@@ -8,7 +8,7 @@ macro_rules! expect {
             .iter()
             .find(|ty| $it.peek().map(|x| x.toktype == **ty).unwrap_or(false));
         match res {
-            None => return Err(ParseError::Expected(&$l)),
+            None => return Err(ParseError::from(ParseErrorType::Expected(&$l))),
             Some(tok) => {
                 $it.next();
                 tok
@@ -67,7 +67,10 @@ impl<I: Iterator<Item = Token>> Iterator for Parser<I> {
             Some(_) => Some({
                 let new = Entry::parse(&mut self.iter);
                 match new {
-                    Err(e) => Err((self.iter.peek().cloned(), e)),
+                    Err(mut e) => {
+                        e.tok = self.iter.peek().cloned();
+                        Err(e)
+                    },
                     Ok(p) => Ok(p),
                 }
             }),
@@ -89,14 +92,14 @@ impl Entry {
             let right_val = Spec::parse(iter)?;
             let left_nr = left
                 .nr_of_options()
-                .ok_or(ParseError::Custom("Too many options on left hand side"))?;
+                .ok_or(ParseError::from(ParseErrorType::Custom("Too many options on left hand side")))?;
             let right_nr = right_val
                 .nr_of_options()
-                .ok_or(ParseError::Custom("Too many options on right hand side"))?;
+                .ok_or(ParseError::from(ParseErrorType::Custom("Too many options on right hand side")))?;
             if left_nr != right_nr {
-                return Err(ParseError::Custom(
+                return Err(ParseError::from(ParseErrorType::Custom(
                     "Left and right sides of mapping must match up",
-                ));
+                )));
             }
             right = Some(right_val);
         }
@@ -207,7 +210,7 @@ impl Spec {
             },
         }
         if string.is_none() {
-            Err(ParseError::Expected(&[TokType::Str]))
+            Err(ParseError::from(ParseErrorType::Expected(&[TokType::Str])))
         } else {
             Ok(Spec {
                 string,
@@ -240,7 +243,7 @@ impl VariantExpr {
             .map(|x| x.toktype == TokType::RBracket)
             .unwrap_or(false)
         {
-            return Err(ParseError::Custom("Must have at least one option"));
+            return Err(ParseError::from(ParseErrorType::Custom("Must have at least one option")));
         }
         let mut specs = Vec::new();
         loop {
@@ -324,7 +327,7 @@ impl Expr {
                 }
             }
         }
-        Err(ParseError::Expected(&[TokType::Str]))
+        Err(ParseError::from(ParseErrorType::Expected(&[TokType::Str])))
     }
 }
 
@@ -359,7 +362,7 @@ mod tests {
     fn success(toks: &[Token], ast: &[Entry]) {
         let iter = toks.iter().cloned().peekable();
         match Parser::new(iter).collect::<ParseResult<Vec<_>>>() {
-            Err(e) => panic!("{:?} at token {:?}", e.1, e.0),
+            Err(e) => panic!("{:?} at token {:?}", e.ty, e.tok),
             Ok(parsed) => assert_eq!(parsed, ast),
         }
     }
@@ -368,7 +371,7 @@ mod tests {
         let res = Parser::new(iter)
             .collect::<ParseResult<Vec<_>>>()
             .unwrap_err();
-        assert_eq!(err, res.1);
+        assert_eq!(err, res);
     }
 
     #[test]
@@ -527,7 +530,7 @@ mod tests {
 
     #[test]
     fn semicolon_error() {
-        fail(&toklist!["a"], ParseError::Expected(&[TokType::Semicolon]));
+        fail(&toklist!["a"], ParseError { tok: None, ty: ParseErrorType::Expected(&[TokType::Semicolon]) });
     }
     // TODO: add more tests
 }

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -537,7 +537,7 @@ mod tests {
         fail(
             &toklist!["a"],
             ParseError {
-                tok: None,
+                tok: None, // `None` means it failed at EOF
                 ty: ParseErrorType::Expected(&[TokType::Semicolon]),
             },
         );

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -70,7 +70,7 @@ impl<I: Iterator<Item = Token>> Iterator for Parser<I> {
                     Err(mut e) => {
                         e.tok = self.iter.peek().cloned();
                         Err(e)
-                    },
+                    }
                     Ok(p) => Ok(p),
                 }
             }),
@@ -90,12 +90,14 @@ impl Entry {
         let mut right = None;
         if eat!(iter, MapsTo) {
             let right_val = Spec::parse(iter)?;
-            let left_nr = left
-                .nr_of_options()
-                .ok_or(ParseError::from(ParseErrorType::Custom("Too many options on left hand side")))?;
-            let right_nr = right_val
-                .nr_of_options()
-                .ok_or(ParseError::from(ParseErrorType::Custom("Too many options on right hand side")))?;
+            let left_nr = left.nr_of_options().ok_or(ParseError {
+                tok: None,
+                ty: ParseErrorType::Custom("Too many options on left hand side"),
+            })?;
+            let right_nr = right_val.nr_of_options().ok_or(ParseError {
+                tok: None,
+                ty: ParseErrorType::Custom("Too many options on right hand side"),
+            })?;
             if left_nr != right_nr {
                 return Err(ParseError::from(ParseErrorType::Custom(
                     "Left and right sides of mapping must match up",
@@ -243,7 +245,9 @@ impl VariantExpr {
             .map(|x| x.toktype == TokType::RBracket)
             .unwrap_or(false)
         {
-            return Err(ParseError::from(ParseErrorType::Custom("Must have at least one option")));
+            return Err(ParseError::from(ParseErrorType::Custom(
+                "Must have at least one option",
+            )));
         }
         let mut specs = Vec::new();
         loop {
@@ -530,7 +534,13 @@ mod tests {
 
     #[test]
     fn semicolon_error() {
-        fail(&toklist!["a"], ParseError { tok: None, ty: ParseErrorType::Expected(&[TokType::Semicolon]) });
+        fail(
+            &toklist!["a"],
+            ParseError {
+                tok: None,
+                ty: ParseErrorType::Expected(&[TokType::Semicolon]),
+            },
+        );
     }
     // TODO: add more tests
 }


### PR DESCRIPTION
This is to replace "implicit information types" such as `(option<lexer::Token>, ParseError)` with just a simple `ParseError`.