### PR TITLE
feat: implement check command

### DIFF
--- a/src/bin/ambit/directories.rs
+++ b/src/bin/ambit/directories.rs
@@ -1,5 +1,6 @@
 use lazy_static::lazy_static;
 use std::fs::{self, File};
+use std::io::Read;
 use std::path::PathBuf;
 
 use ambit::error::{AmbitError, AmbitResult};
@@ -35,6 +36,21 @@ impl AmbitPath {
             Some(e) => Ok(e),
             None => Err(AmbitError::Other(
                 "Could not yield path as &str slice".to_string(),
+            )),
+        }
+    }
+
+    // Fetch the content of a path if it is AmbitPathKind::File
+    pub fn as_string(&self) -> AmbitResult<String> {
+        match self.kind {
+            AmbitPathKind::File => {
+                let mut file = File::open(&self.path)?;
+                let mut content = String::new();
+                file.read_to_string(&mut content)?;
+                Ok(content)
+            }
+            AmbitPathKind::Directory => Err(AmbitError::Other(
+                "Getting content of a directory is not supported".to_string(),
             )),
         }
     }

--- a/src/bin/ambit/main.rs
+++ b/src/bin/ambit/main.rs
@@ -29,7 +29,7 @@ fn get_config_entries() -> AmbitResult<Vec<config::parser::Entry>> {
     let content = AMBIT_PATHS.config.as_string()?;
     match config::get_entries(content.chars().peekable()).collect::<Result<Vec<_>, _>>() {
         Ok(entries) => Ok(entries),
-        Err(e) => return Err(AmbitError::Parse(e)),
+        Err(e) => Err(AmbitError::Parse(e)),
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,6 +4,8 @@ pub mod parser;
 use lexer::Lexer;
 pub use parser::{Entry, Parser};
 
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
 use std::iter::Peekable;
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
@@ -17,6 +19,15 @@ pub struct ParseError {
     pub ty: ParseErrorType,
     // Some(_) if it failed at a token, or None if it failed at EOF.
     pub tok: Option<lexer::Token>,
+}
+
+impl Error for ParseError {}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        // TODO: Output parse error nicely
+        write!(f, "{:?}", self)
+    }
 }
 
 impl From<ParseErrorType> for ParseError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,18 +1,28 @@
-use std::process;
-use std::{fmt, io};
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+use std::{io, process};
+
+use crate::config;
 
 pub type AmbitResult<T> = Result<T, AmbitError>;
 
 #[derive(Debug)]
 pub enum AmbitError {
     Io(io::Error),
+    // TODO: As of now, a single ParseError is returned from config::get_entries
+    //       Future changes may result in a Vec<ParseError> being returned.
+    //       This should be taken care of.
+    Parse(config::ParseError),
     Other(String),
 }
 
-impl fmt::Display for AmbitError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Error for AmbitError {}
+
+impl Display for AmbitError {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self {
             AmbitError::Io(ref e) => e.fmt(f),
+            AmbitError::Parse(ref e) => e.fmt(f),
             AmbitError::Other(ref s) => f.write_str(&**s),
         }
     }


### PR DESCRIPTION
The `check` command can be used to "Check ambit configuration for errors". In other words, it retrieves config entries and outputs if there are any syntax errors present.

In addition to the check command, this PR introduces the `sync` command; however, this is unimplemented.

In terms of errors, this change makes `AmbitError` and `ParseError` implement `std::error::Error`.