### PR TITLE
refactor: rename path creation function

### DIFF
--- a/src/bin/ambit/main.rs
+++ b/src/bin/ambit/main.rs
@@ -62,11 +62,13 @@ mod cmd {
             // Pass in ambit repo path as last argument to ensure that it is always cloned to the known path
             .arg(repo_path)
             .status()?;
-        if status.success() {
-            println!("Successfully cloned repository to {}", repo_path);
-            return Ok(());
+        match status.success() {
+            true => {
+                println!("Successfully cloned repository to {}", repo_path);
+                Ok(())
+            }
+            false => Err(AmbitError::Other("Failed to clone repository".to_string())),
         }
-        Err(AmbitError::Other("Failed to clone repository".to_string()))
     }
 
     // Check ambit configuration for errors

--- a/src/bin/ambit/main.rs
+++ b/src/bin/ambit/main.rs
@@ -28,10 +28,9 @@ fn ensure_paths_exist(force: bool) -> AmbitResult<()> {
 // Fetch entries from config file and return as vector
 fn get_config_entries() -> AmbitResult<Vec<config::parser::Entry>> {
     let content = AMBIT_PATHS.config.as_string()?;
-    match config::get_entries(content.chars().peekable()).collect::<Result<Vec<_>, _>>() {
-        Ok(entries) => Ok(entries),
-        Err(e) => Err(AmbitError::Parse(e)),
-    }
+    config::get_entries(content.chars().peekable())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(AmbitError::Parse)
 }
 
 mod cmd {


### PR DESCRIPTION
This PR simply renames the `create_paths()` function to `ensure_paths_exist()`. It also removes unnecessary `match` statements.