### PR TITLE
refactor(config): change file structure, add tests

### DIFF
--- a/src/bin/ambit/main.rs
+++ b/src/bin/ambit/main.rs
@@ -26,7 +26,7 @@ fn ensure_paths_exist(force: bool) -> AmbitResult<()> {
 }
 
 // Fetch entries from config file and return as vector
-fn get_config_entries() -> AmbitResult<Vec<config::parser::Entry>> {
+fn get_config_entries() -> AmbitResult<Vec<config::Entry>> {
     let content = AMBIT_PATHS.config.as_string()?;
     config::get_entries(content.chars().peekable())
         .collect::<Result<Vec<_>, _>>()

--- a/src/config/ast.rs
+++ b/src/config/ast.rs
@@ -73,7 +73,7 @@ impl MatchExpr {
                 return &case.1;
             }
         }
-        return &self.default;
+        &self.default
     }
 }
 

--- a/src/config/ast.rs
+++ b/src/config/ast.rs
@@ -1,0 +1,92 @@
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct Entry {
+    pub left: Spec,
+    pub right: Option<Spec>,
+}
+
+// A `Spec` specifies a fragment of a path, e.g. "~/.config/[nvim/init.vim, spectrwm.conf]".
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct Spec {
+    pub string: Option<String>,
+    pub spectype: SpecType,
+}
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum SpecType {
+    None,
+    Variant(Box<VariantExpr>, Option<Box<Spec>>),
+    Match(Box<MatchExpr>, Option<Box<Spec>>),
+}
+
+impl Spec {
+    // Returns None if the nr. of options is larger than usize::MAX.
+    pub fn nr_of_options(&self) -> Option<usize> {
+        match &self.spectype {
+            SpecType::None => Some(1),
+            SpecType::Match(_, spec) => spec.as_ref().map(|s| s.nr_of_options()).unwrap_or(Some(1)),
+            SpecType::Variant(expr, spec) => {
+                let exprnr = expr.nr_of_options()?;
+                let specnr = spec
+                    .as_ref()
+                    .map(|s| s.nr_of_options())
+                    .unwrap_or(Some(1))?;
+                exprnr.checked_mul(specnr)
+            }
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct VariantExpr {
+    pub specs: Vec<Spec>,
+}
+impl VariantExpr {
+    // Returns None if the nr. of options is larger than usize::MAX.
+    pub fn nr_of_options(&self) -> Option<usize> {
+        self.specs.iter().try_fold(0usize, |nr, spec| {
+            spec.nr_of_options()
+                .and_then(|specnr| specnr.checked_add(nr))
+        })
+    }
+}
+
+// Matches, based on the expr, which spec to produce.
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct MatchExpr {
+    pub cases: Vec<(Expr, Spec)>,
+    pub default: Spec,
+}
+impl MatchExpr {
+    pub fn resolve(&self) -> &Spec {
+        use std::env::consts::OS;
+        let os = match OS {
+            "linux" => Some(ExprType::Linux),
+            "windows" => Some(ExprType::Windows),
+            "macos" => Some(ExprType::Macos),
+            "freebsd" | "netbsd" | "openbsd" => Some(ExprType::Bsd),
+            _ => None,
+        };
+        for case in &self.cases {
+            if (cfg!(unix) && case.0.exprtype == ExprType::Unix)
+                || os.as_ref().map(|x| *x == case.0.exprtype).unwrap_or(false)
+            {
+                // it matches
+                return &case.1;
+            }
+        }
+        return &self.default;
+    }
+}
+
+// Something that is either true or false, depending on the system.
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct Expr {
+    pub exprtype: ExprType,
+}
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum ExprType {
+    Windows,
+    Linux,
+    Macos,
+    Unix,
+    Bsd,
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,8 +1,10 @@
+pub mod ast;
 pub mod lexer;
 pub mod parser;
 
+pub use ast::Entry;
 use lexer::Lexer;
-pub use parser::{Entry, Parser};
+pub use parser::Parser;
 
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -143,7 +143,6 @@ impl Spec {
                             // the grammar wouldn't be LL(1).
                             {
                                 if starts_spec(iter) {
-                                    // It *probably* doesn't end here.
                                     Some(Box::new(Spec::parse(iter)?))
                                 } else {
                                     None
@@ -155,14 +154,16 @@ impl Spec {
                 TokType::LBracket => {
                     return Ok(Spec {
                         string,
-                        spectype: SpecType::Variant(Box::new(VariantExpr::parse(iter)?), {
-                            if starts_spec(iter) {
-                                // It *probably* doesn't end here.
-                                Some(Box::new(Spec::parse(iter)?))
-                            } else {
-                                None
+                        spectype: SpecType::Variant(
+                            Box::new(VariantExpr::parse(iter)?), 
+                            {
+                                if starts_spec(iter) {
+                                    Some(Box::new(Spec::parse(iter)?))
+                                } else {
+                                    None
+                                }
                             }
-                        }),
+                        ),
                     });
                 }
                 _ => {}

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -154,16 +154,13 @@ impl Spec {
                 TokType::LBracket => {
                     return Ok(Spec {
                         string,
-                        spectype: SpecType::Variant(
-                            Box::new(VariantExpr::parse(iter)?), 
-                            {
-                                if starts_spec(iter) {
-                                    Some(Box::new(Spec::parse(iter)?))
-                                } else {
-                                    None
-                                }
+                        spectype: SpecType::Variant(Box::new(VariantExpr::parse(iter)?), {
+                            if starts_spec(iter) {
+                                Some(Box::new(Spec::parse(iter)?))
+                            } else {
+                                None
                             }
-                        ),
+                        }),
                     });
                 }
                 _ => {}

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -1,20 +1,21 @@
-use crate::config::{lexer::*, ParseError, ParseErrorType, ParseResult};
+use crate::config::{ast::*, lexer::*, ParseError, ParseErrorType, ParseResult};
 
 use std::iter::Peekable;
 
-macro_rules! expect {
-    ($it:ident,$l:tt) => {{
-        let res = $l
-            .iter()
-            .find(|ty| $it.peek().map(|x| x.toktype == **ty).unwrap_or(false));
-        match res {
-            None => return Err(ParseError::from(ParseErrorType::Expected(&$l))),
-            Some(tok) => {
-                $it.next();
-                tok
-            }
+fn expect<I: Iterator<Item = Token>>(
+    iter: &mut Peekable<I>,
+    choices: &'static [TokType],
+) -> ParseResult<TokType> {
+    let res = choices
+        .iter()
+        .find(|ty| iter.peek().map(|x| x.toktype == **ty).unwrap_or(false));
+    match res {
+        None => Err(ParseError::from(ParseErrorType::Expected(choices))),
+        Some(tok) => {
+            iter.next();
+            Ok(*tok)
         }
-    }};
+    }
 }
 
 macro_rules! eat {
@@ -42,12 +43,6 @@ macro_rules! eat {
             false
         }
     }};
-}
-
-macro_rules! ends {
-    ($it:ident) => {
-        $it.peek().is_none()
-    };
 }
 
 pub struct Parser<I: Iterator<Item = Token>> {
@@ -79,13 +74,8 @@ impl<I: Iterator<Item = Token>> Iterator for Parser<I> {
 }
 
 // entry -> spec ("=>" spec)? ";"
-#[derive(PartialEq, Eq, Debug, Clone)]
-pub struct Entry {
-    left: Spec,
-    right: Option<Spec>,
-}
 impl Entry {
-    pub fn parse<I: Iterator<Item = Token>>(iter: &mut Peekable<I>) -> Result<Entry, ParseError> {
+    pub fn parse<I: Iterator<Item = Token>>(iter: &mut Peekable<I>) -> ParseResult<Entry> {
         let left = Spec::parse(iter)?;
         let mut right = None;
         if eat!(iter, MapsTo) {
@@ -105,46 +95,17 @@ impl Entry {
             }
             right = Some(right_val);
         }
-        expect!(iter, [TokType::Semicolon]);
+        expect(iter, &[TokType::Semicolon])?;
         Ok(Entry { left, right })
     }
 }
 
-// A `Spec` specifies a fragment of a path, e.g. "~/.config/[nvim/init.vim, spectrwm.conf]".
 /* spec -> str
  *      -> str? variant-expr spec?
  *      -> str? match-expr spec?
  */
-#[derive(PartialEq, Eq, Debug, Clone)]
-struct Spec {
-    string: Option<String>,
-    spectype: SpecType,
-}
-#[derive(PartialEq, Eq, Debug, Clone)]
-enum SpecType {
-    None,
-    Variant(Box<VariantExpr>, Option<Box<Spec>>),
-    Match(Box<MatchExpr>, Option<Box<Spec>>),
-}
 impl Spec {
-    /* Returns None if the nr. of options
-     * overflows `usize`.
-     */
-    pub fn nr_of_options(&self) -> Option<usize> {
-        match &self.spectype {
-            SpecType::None => Some(1),
-            SpecType::Match(_, spec) => spec.as_ref().map(|s| s.nr_of_options()).unwrap_or(Some(1)),
-            SpecType::Variant(expr, spec) => {
-                let exprnr = expr.nr_of_options()?;
-                let specnr = spec
-                    .as_ref()
-                    .map(|s| s.nr_of_options())
-                    .unwrap_or(Some(1))?;
-                exprnr.checked_mul(specnr)
-            }
-        }
-    }
-    pub fn parse<I: Iterator<Item = Token>>(iter: &mut Peekable<I>) -> Result<Spec, ParseError> {
+    pub fn parse<I: Iterator<Item = Token>>(iter: &mut Peekable<I>) -> ParseResult<Spec> {
         let mut string = None;
         if iter
             .peek()
@@ -158,18 +119,16 @@ impl Spec {
                     .expect("Internal error: string expected!"),
             );
         }
-        fn probably_ends_spec<I: Iterator<Item = Token>>(iter: &mut Peekable<I>) -> bool {
-            // Check if the iterator "probably ends" here,
-            // or we need to do another round of parsing.
-            ends!(iter)
-                || iter
-                    .peek()
-                    .map(|next| {
-                        [TokType::Semicolon, TokType::MapsTo]
-                            .iter()
-                            .any(|x| next.toktype == *x)
-                    })
-                    .unwrap_or(false)
+        fn starts_spec<I: Iterator<Item = Token>>(iter: &mut Peekable<I>) -> bool {
+            // Check if a new spec could start here.
+            // Note that this should be updated if the spec specification changes.
+            iter.peek()
+                .map(|next| {
+                    [TokType::Str, TokType::LBrace, TokType::LBracket]
+                        .iter()
+                        .any(|x| next.toktype == *x)
+                })
+                .unwrap_or(false)
         }
         // optimization
         match iter.peek() {
@@ -183,12 +142,11 @@ impl Spec {
                             // If we didn't do this hack,
                             // the grammar wouldn't be LL(1).
                             {
-                                if probably_ends_spec(iter) {
-                                    // It ends here.
-                                    None
-                                } else {
+                                if starts_spec(iter) {
                                     // It *probably* doesn't end here.
                                     Some(Box::new(Spec::parse(iter)?))
+                                } else {
+                                    None
                                 }
                             },
                         ),
@@ -198,12 +156,11 @@ impl Spec {
                     return Ok(Spec {
                         string,
                         spectype: SpecType::Variant(Box::new(VariantExpr::parse(iter)?), {
-                            if probably_ends_spec(iter) {
-                                // It ends here.
-                                None
-                            } else {
+                            if starts_spec(iter) {
                                 // It *probably* doesn't end here.
                                 Some(Box::new(Spec::parse(iter)?))
+                            } else {
+                                None
                             }
                         }),
                     });
@@ -223,22 +180,9 @@ impl Spec {
 }
 
 // variant-expr -> [ spec (, spec)* ]
-#[derive(PartialEq, Eq, Debug, Clone)]
-struct VariantExpr {
-    specs: Vec<Spec>,
-}
 impl VariantExpr {
-    // Returns None if the nr of options is larger than usize::MAX.
-    pub fn nr_of_options(&self) -> Option<usize> {
-        self.specs.iter().try_fold(0usize, |nr, spec| {
-            spec.nr_of_options()
-                .and_then(|specnr| specnr.checked_add(nr))
-        })
-    }
-    pub fn parse<I: Iterator<Item = Token>>(
-        iter: &mut Peekable<I>,
-    ) -> Result<VariantExpr, ParseError> {
-        expect!(iter, [TokType::LBracket]);
+    pub fn parse<I: Iterator<Item = Token>>(iter: &mut Peekable<I>) -> ParseResult<VariantExpr> {
+        expect(iter, &[TokType::LBracket])?;
         // Better error message.
         if iter
             .peek()
@@ -256,59 +200,39 @@ impl VariantExpr {
                 break;
             }
         }
-        expect!(iter, [TokType::RBracket]);
+        expect(iter, &[TokType::RBracket])?;
         Ok(VariantExpr { specs })
     }
 }
 
-// Matches, based on the expr, which spec to produce.
 // match-expr -> { (expr ":" spec ":")* "default" ":" spec }
-#[derive(PartialEq, Eq, Debug, Clone)]
-struct MatchExpr {
-    cases: Vec<(Expr, Spec)>,
-    default: Spec,
-}
 impl MatchExpr {
-    pub fn parse<I: Iterator<Item = Token>>(
-        iter: &mut Peekable<I>,
-    ) -> Result<MatchExpr, ParseError> {
-        expect!(iter, [TokType::LBrace]);
+    pub fn parse<I: Iterator<Item = Token>>(iter: &mut Peekable<I>) -> ParseResult<MatchExpr> {
+        expect(iter, &[TokType::LBrace])?;
         let mut cases = Vec::new();
         loop {
             if eat!(iter, "default") {
-                expect!(iter, [TokType::Colon]);
+                expect(iter, &[TokType::Colon])?;
                 let ret = MatchExpr {
                     cases,
                     default: Spec::parse(iter)?,
                 };
-                expect!(iter, [TokType::RBrace]);
+                expect(iter, &[TokType::RBrace])?;
                 return Ok(ret);
             }
             let expr = Expr::parse(iter)?;
-            expect!(iter, [TokType::Colon]);
+            expect(iter, &[TokType::Colon])?;
             let spec = Spec::parse(iter)?;
             cases.push((expr, spec));
-            expect!(iter, [TokType::Comma]);
+            expect(iter, &[TokType::Comma])?;
         }
     }
 }
 
 // expr -> "windows" | "linux" | "macos" | "unix" | "bsd"
 // (for now)
-#[derive(PartialEq, Eq, Debug, Clone)]
-struct Expr {
-    exprtype: ExprType,
-}
-#[derive(PartialEq, Eq, Debug, Clone)]
-enum ExprType {
-    Windows,
-    Linux,
-    Macos,
-    Unix,
-    Bsd,
-}
 impl Expr {
-    pub fn parse<I: Iterator<Item = Token>>(iter: &mut Peekable<I>) -> Result<Expr, ParseError> {
+    pub fn parse<I: Iterator<Item = Token>>(iter: &mut Peekable<I>) -> ParseResult<Expr> {
         macro_rules! exprtype {
             ($i:ident) => {{
                 iter.next();
@@ -528,6 +452,53 @@ mod tests {
                         None,
                     ),
                 }),
+            }],
+        );
+    }
+
+    #[test]
+    fn nested_variant_with_only_one_option() {
+        success(
+            &toklist![
+                ".config/",
+                TokType::LBracket,
+                "kitty/",
+                TokType::LBracket,
+                "kitty.conf",
+                TokType::Comma,
+                "theme.conf",
+                TokType::RBracket,
+                TokType::RBracket,
+                TokType::Semicolon
+            ],
+            &[Entry {
+                left: Spec {
+                    string: Some(".config/".to_owned()),
+                    spectype: SpecType::Variant(
+                        Box::new(VariantExpr {
+                            specs: vec![Spec {
+                                string: Some("kitty/".to_owned()),
+                                spectype: SpecType::Variant(
+                                    Box::new(VariantExpr {
+                                        specs: vec![
+                                            Spec {
+                                                string: Some("kitty.conf".to_owned()),
+                                                spectype: SpecType::None,
+                                            },
+                                            Spec {
+                                                string: Some("theme.conf".to_owned()),
+                                                spectype: SpecType::None,
+                                            },
+                                        ],
+                                    }),
+                                    None,
+                                ),
+                            }],
+                        }),
+                        None,
+                    ),
+                },
+                right: None,
             }],
         );
     }


### PR DESCRIPTION
This changes the file structure to split up the responsibilities of each file (config/parser.rs is for parsing, config/ast.rs is for defining the AST types). It also adds a test and fixes a bug involving it.