### PR TITLE
refactor: rename config and improve error message

### DIFF
--- a/src/bin/ambit/directories.rs
+++ b/src/bin/ambit/directories.rs
@@ -47,12 +47,10 @@ impl AmbitPath {
                 let mut file = match File::open(&self.path) {
                     Ok(file) => file,
                     Err(e) => {
-                        // Format error nicely to notify user of error from file open attempt
-                        return Err(AmbitError::Other(format!(
-                            "Failed to read `{}`\n\nCaused by:\n  {}",
-                            self.to_str()?,
-                            e
-                        )));
+                        return Err(AmbitError::File {
+                            path: String::from(self.to_str()?),
+                            error: e,
+                        })
                     }
                 };
                 let mut content = String::new();

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,16 +30,13 @@ impl Error for AmbitError {
 
 impl Display for AmbitError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let result = match self {
+        match self {
             AmbitError::Io(ref e) => e.fmt(f),
             AmbitError::Parse(ref e) => e.fmt(f),
             AmbitError::File { path, .. } => f.write_fmt(format_args!("Failed to read `{}`", path)),
             AmbitError::Other(ref s) => f.write_str(s.as_str()),
-        };
-        if result.is_err() {
-            // Error encountered from previous match
-            return result;
-        } else if let Some(source) = self.source() {
+        }?;
+        if let Some(source) = self.source() {
             // Report error with additional causation if there is a source
             f.write_fmt(format_args!("\n\nCaused by:\n  {}", source))?;
         }


### PR DESCRIPTION
Renames the configuration file from `config` to `config.ambit`. This will make it easier to recognize the ambit file type (which may make syntax highlighting implementation easier in the future).

This PR also improves the error on `File::open()` function call by explicitly informing the user of the expected configuration location and the error received:

```
ERROR: Failed to read `/home/user/.config/ambit/config.ambit`

Caused by:
  No such file or directory (os error 2)
```

Previous behavior only printed out the reason for failure (`No such file or directory (os error 2)`) which may be vague for the end user.