### PR TITLE
docs: update config name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For example, to show the working tree status of the repository:
 
 ## Configuration
 
-`ambit` will search for a configuration file located at `${HOME}/.config/ambit/config`.
+`ambit` will search for a configuration file located at `${HOME}/.config/ambit/config.ambit`.
 
 ## Installation
 


### PR DESCRIPTION
The README.md stated the configuration file name as `config` rather than `config.ambit` as changed in PR #26. 
This PR fixes this.