### PR TITLE
ci: add Windows Server 2019 testing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,10 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-2019]
     steps:
       - name: Git checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Adds testing for Windows. (This may be useful later on for when we do platform-specific stuff.) 