### PR TITLE
feat: allow match expressions with no default

### DIFF
--- a/src/config/ast.rs
+++ b/src/config/ast.rs
@@ -120,16 +120,3 @@ impl From<ExprType> for Expr {
         Expr { exprtype }
     }
 }
-// To help test resolution.
-#[cfg(test)]
-impl Expr {
-    pub fn incorrect_os() -> Self {
-        Expr {
-            exprtype: if cfg!(windows) {
-                ExprType::Linux
-            } else {
-                ExprType::Windows
-            },
-        }
-    }
-}

--- a/src/config/strgen.rs
+++ b/src/config/strgen.rs
@@ -308,16 +308,7 @@ mod tests {
                 string: Some("d".to_owned()),
                 spectype: SpecType::match_expr(
                     vec![
-                        (
-                            Expr {
-                                exprtype: if cfg!(windows) {
-                                    ExprType::Linux
-                                } else {
-                                    ExprType::Windows
-                                },
-                            },
-                            Spec::from("g"),
-                        ),
+                        (Expr::incorrect_os(), Spec::from("g")),
                         (ExprType::Any.into(), Spec::from("e")),
                     ],
                     Some(Spec::from("f")),
@@ -328,22 +319,13 @@ mod tests {
     }
 
     #[test]
-    fn match_that_cannot_resolve() {
+    fn unresolvable_match() {
         results_in(
             // Equivalent to `d{ incorrect-os: g, }f`.
             Spec {
                 string: Some("d".to_owned()),
                 spectype: SpecType::match_expr(
-                    vec![(
-                        Expr {
-                            exprtype: if cfg!(windows) {
-                                ExprType::Linux
-                            } else {
-                                ExprType::Windows
-                            },
-                        },
-                        Spec::from("g"),
-                    )],
+                    vec![(Expr::incorrect_os(), Spec::from("g"))],
                     Some(Spec::from("f")),
                 ),
             },

--- a/src/config/strgen.rs
+++ b/src/config/strgen.rs
@@ -284,6 +284,16 @@ mod tests {
         assert_eq!(yielded, expected);
     }
 
+    fn incorrect_os() -> Expr {
+        Expr {
+            exprtype: if cfg!(windows) {
+                ExprType::Linux
+            } else {
+                ExprType::Windows
+            },
+        }
+    }
+
     #[test]
     fn basic_string() {
         results_in(Spec::from("abc"), vec!["abc"]);
@@ -308,7 +318,7 @@ mod tests {
                 string: Some("d".to_owned()),
                 spectype: SpecType::match_expr(
                     vec![
-                        (Expr::incorrect_os(), Spec::from("g")),
+                        (incorrect_os(), Spec::from("g")),
                         (ExprType::Any.into(), Spec::from("e")),
                     ],
                     Some(Spec::from("f")),
@@ -325,7 +335,7 @@ mod tests {
             Spec {
                 string: Some("d".to_owned()),
                 spectype: SpecType::match_expr(
-                    vec![(Expr::incorrect_os(), Spec::from("g"))],
+                    vec![(incorrect_os(), Spec::from("g"))],
                     Some(Spec::from("f")),
                 ),
             },


### PR DESCRIPTION
This PR fixes #12.

It also refactors `Expr` to make test-making easier with `impl From<ExprType> for Expr`.