### PR TITLE
test: add integration test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ path = "src/bin/ambit/main.rs"
 clap = "2.33.3"
 dirs = "3.0.1"
 lazy_static = "1.4.0"
+
+[dev-dependencies]
+assert_cmd = "1.0.3"
+tempfile = "3.2.0"

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,182 @@
+use assert_cmd::{assert::Assert, Command};
+use std::{
+    ffi::OsStr,
+    fs::{self, File},
+    path::PathBuf,
+};
+use tempfile::TempDir;
+
+#[derive(Debug)]
+pub struct AmbitTester {
+    config_path: PathBuf,
+    repo_path: PathBuf,
+    executable: Command,
+}
+// Builder pattern implementation
+impl AmbitTester {
+    // Allow temp_dir to be passed so it can be owned from outside of the struct.
+    fn from_temp_dir(temp_dir: &TempDir) -> Self {
+        let config_path = temp_dir.path().join("config.ambit");
+        let repo_path = temp_dir.path().join("repo");
+        let mut executable = Command::cargo_bin("ambit").unwrap();
+        // Set environment variables.
+        // AMBIT_HOME_PATH is set as temp_dir. This is important as it will be the prefix path of potential synced files.
+        executable.env("AMBIT_HOME_PATH", temp_dir.path().as_os_str());
+        executable.env("AMBIT_CONFIG_PATH", config_path.as_os_str());
+        executable.env("AMBIT_REPO_PATH", repo_path.as_os_str());
+        Self {
+            config_path,
+            repo_path,
+            executable,
+        }
+    }
+
+    // Write content to configuration file.
+    fn with_config(self, content: &str) -> Self {
+        fs::write(&self.config_path, content).expect("Unable to write to file");
+        self
+    }
+
+    // Create a custom file in repo_path directory. Mimics repo_file.
+    fn with_repo_file(self, name: &str) -> Self {
+        File::create(self.repo_path.join(name)).unwrap();
+        self
+    }
+
+    // Creates configuration file and repository directory with .git.
+    fn with_default_paths(self) -> Self {
+        fs::create_dir_all(&self.repo_path.join(".git")).unwrap();
+        File::create(&self.config_path).unwrap();
+        self
+    }
+
+    fn arg<S: AsRef<OsStr>>(mut self, arg: S) -> Self {
+        self.executable.arg(arg);
+        self
+    }
+
+    fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.executable.args(args);
+        self
+    }
+
+    fn assert(mut self) -> Assert {
+        // Consumes self
+        self.executable.assert()
+    }
+}
+impl Default for AmbitTester {
+    // Default should be used when direct access to temporary directory is not needed.
+    fn default() -> Self {
+        AmbitTester::from_temp_dir(&TempDir::new().unwrap())
+    }
+}
+
+// Returns if a is symlinked to b (a -> b).
+fn is_symlinked(a: PathBuf, b: PathBuf) -> bool {
+    fs::read_link(a)
+        .map(|link_path| {
+            println!("{}", link_path.display());
+            link_path == b
+        })
+        .unwrap_or(false)
+}
+
+#[test]
+fn init_repo_already_exists() {
+    // Expect an error when attempting to initialize without force flag.
+    // The repository directory is already created when calling `with_default_paths()`.
+    AmbitTester::default()
+        .with_default_paths()
+        .arg("init")
+        .assert()
+        .stderr("ERROR: Dotfile repository already exists.\nUse '-f' flag to overwrite.\n");
+}
+
+#[test]
+fn init_force_overwrites() {
+    AmbitTester::default()
+        .with_default_paths()
+        .args(vec!["init", "-f"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn clone_repo_already_exists() {
+    // Expect an error when attempting to clone without force flag.
+    AmbitTester::default()
+        .with_default_paths()
+        .args(vec!["clone", "https://github.com/plamorg/ambit"])
+        .assert()
+        .stderr("ERROR: Dotfile repository already exists.\nUse '-f' flag to overwrite.\n");
+}
+
+#[test]
+fn sync_without_repo() {
+    // Error should occur if attempting to sync without initializing.
+    // `with_default_paths` is omitted here.
+    AmbitTester::default().arg("sync").assert().stderr(
+        "ERROR: Dotfile repository does not exist. Run `init` or `clone` before syncing.\n",
+    );
+}
+
+#[test]
+fn sync_host_file_already_exists() {
+    // The host file already exists but is not symlinked to repo file.
+    let temp_dir = TempDir::new().unwrap();
+    File::create(temp_dir.path().join("host.txt")).unwrap();
+    AmbitTester::from_temp_dir(&temp_dir)
+        .with_default_paths()
+        .with_repo_file("repo.txt")
+        .with_config("repo.txt => host.txt;")
+        .arg("sync")
+        .assert()
+        .failure();
+}
+
+#[test]
+fn sync_repo_file_does_not_exist() {
+    // Repo file should exist for sync to work.
+    AmbitTester::default()
+        .with_default_paths()
+        .with_config("repo.txt => host.txt;")
+        .arg("sync")
+        .assert()
+        .failure();
+}
+
+#[test]
+fn sync_normal() {
+    let temp_dir = TempDir::new().unwrap();
+    AmbitTester::from_temp_dir(&temp_dir)
+        .with_default_paths()
+        .with_repo_file("repo.txt")
+        .with_config("repo.txt => host.txt;")
+        .arg("sync")
+        .assert()
+        .success();
+    // Assert that host.txt is symlinked to repo.txt
+    assert!(is_symlinked(
+        temp_dir.path().join("host.txt"),
+        temp_dir.path().join("repo").join("repo.txt")
+    ));
+}
+
+#[test]
+fn sync_dry_run_should_not_symlink() {
+    let temp_dir = TempDir::new().unwrap();
+    AmbitTester::from_temp_dir(&temp_dir)
+        .with_default_paths()
+        .with_repo_file("repo.txt")
+        .with_config("repo.txt => should-not-exist.txt;")
+        .args(vec!["sync", "--dry-run"])
+        .assert()
+        .success();
+    // Since this is a dry-run, the host_file should not exist.
+    assert!(!temp_dir.path().join("should_not_exist.txt").exists());
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -178,5 +178,5 @@ fn sync_dry_run_should_not_symlink() {
         .assert()
         .success();
     // Since this is a dry-run, the host_file should not exist.
-    assert!(!temp_dir.path().join("should_not_exist.txt").exists());
+    assert!(!temp_dir.path().join("should-not-exist.txt").exists());
 }


### PR DESCRIPTION
This PR provides CLI-based integration tests.  To enable this, the PR introduces a way to change 3 paths through environment variables: (1) `AMBIT_HOME_PATH`, (2) `AMBIT_CONFIG_PATH`, and (3) `AMBIT_REPO_PATH`.

The integration tests are located in `tests/integration_tests.rs`. This file contains a struct named `AmbitTester` which implements a builder pattern to allow different filesystem/configuration environments to be simulated. This is done to ensure that the tests have no side-effects and are isolated from each other.

This testing framework should mean that future integration tests can be uniformly implemented.

To accomplish this, two `dev-dependencies` were added (`Cargo.toml`):
* assert_cmd
* tempfile