### PR TITLE
fix: make sync create host file parent directories

### DIFF
--- a/src/bin/ambit/cmd.rs
+++ b/src/bin/ambit/cmd.rs
@@ -121,6 +121,10 @@ pub fn sync(dry_run: bool, quiet: bool) -> AmbitResult<()> {
         }
         if !already_symlinked {
             if !dry_run {
+                if let Some(parent) = host_file.path.parent() {
+                    // Create parent directories of host file if it does not terminate in a root or prefix.
+                    fs::create_dir_all(parent)?;
+                }
                 // Attempt to perform symlink
                 if let Err(e) = symlink(&repo_file.path, &host_file.path) {
                     // Symlink went wrong

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -180,3 +180,22 @@ fn sync_dry_run_should_not_symlink() {
     // Since this is a dry-run, the host_file should not exist.
     assert!(!temp_dir.path().join("should-not-exist.txt").exists());
 }
+
+#[test]
+fn sync_creates_host_parent_directories() {
+    // Parent directories of the host file should be created if they do not exist.
+    // We want to ensure that the following test does not fail due to "No such file or directory" error.
+    let temp_dir = TempDir::new().unwrap();
+    AmbitTester::from_temp_dir(&temp_dir)
+        .with_default_paths()
+        .with_repo_file("repo.txt")
+        .with_config("repo.txt => a/b/host.txt;")
+        .arg("sync")
+        .assert()
+        .success();
+    // Assert that a/b/host.txt is symlinked to repo.txt
+    assert!(is_symlinked(
+        temp_dir.path().join("a").join("b").join("host.txt"),
+        temp_dir.path().join("repo").join("repo.txt"),
+    ));
+}


### PR DESCRIPTION
Prior to this PR, `ambit sync` would return an error if the parent directories of the host file didn't exist. This PR fixes this by recursively creating the host file's parent directories in the `sync` function.

An additional integration test pertaining to this fix is added to ensure this functionality is permitted in future iterations.