### PR TITLE
feat(config): implement not os and not host

### DIFF
--- a/src/config/ast.rs
+++ b/src/config/ast.rs
@@ -105,6 +105,8 @@ pub struct CommaList<T: SimpleParse> {
 pub enum Expr {
     Os(Vec<String>),
     Host(Vec<String>),
+    NotOs(Vec<String>),
+    NotHost(Vec<String>),
     // The "Default" exprtype,
     // so-named due to conflicts with the Default iterator.
     Any,
@@ -114,6 +116,8 @@ impl Expr {
         match self {
             Expr::Os(oss) => oss.iter().any(|os| std::env::consts::OS == os),
             Expr::Host(hosts) => hosts.iter().any(|host| &*HOSTNAME == host),
+            Expr::NotOs(oss) => oss.iter().any(|os| std::env::consts::OS != os),
+            Expr::NotHost(hosts) => hosts.iter().any(|host| &*HOSTNAME != host),
             Expr::Any => true,
         }
     }

--- a/src/config/ast.rs
+++ b/src/config/ast.rs
@@ -53,6 +53,14 @@ impl From<&str> for Spec {
         }
     }
 }
+impl From<SpecType> for Spec {
+    fn from(t: SpecType) -> Self {
+        Spec {
+            string: None,
+            spectype: t,
+        }
+    }
+}
 impl SpecType {
     pub fn variant_expr(specs: Vec<Spec>, rest: Option<Spec>) -> Self {
         SpecType::Variant(Box::new(VariantExpr { specs }), rest.map(Box::new))
@@ -116,8 +124,8 @@ impl Expr {
         match self {
             Expr::Os(oss) => oss.iter().any(|os| std::env::consts::OS == os),
             Expr::Host(hosts) => hosts.iter().any(|host| &*HOSTNAME == host),
-            Expr::NotOs(oss) => oss.iter().any(|os| std::env::consts::OS != os),
-            Expr::NotHost(hosts) => hosts.iter().any(|host| &*HOSTNAME != host),
+            Expr::NotOs(oss) => oss.iter().all(|os| std::env::consts::OS != os),
+            Expr::NotHost(hosts) => hosts.iter().all(|host| &*HOSTNAME != host),
             Expr::Any => true,
         }
     }

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -336,10 +336,10 @@ mod tests {
                 TokType::Semicolon
             ],
             &[Entry {
-                left: Spec {
-                    string: None,
-                    spectype: SpecType::variant_expr(vec![Spec::from("a"), Spec::from("b")], None),
-                },
+                left: Spec::from(SpecType::variant_expr(
+                    vec![Spec::from("a"), Spec::from("b")],
+                    None,
+                )),
                 right: None,
             }],
         );
@@ -365,16 +365,13 @@ mod tests {
                 TokType::Semicolon
             ],
             &[Entry {
-                left: Spec {
-                    string: None,
-                    spectype: SpecType::match_expr(
-                        vec![
-                            (Expr::Any, Spec::from("b")),
-                            (Expr::Os(vec!["windows".to_owned()]), Spec::from("a")),
-                        ],
-                        Some(Spec::from("c")),
-                    ),
-                },
+                left: Spec::from(SpecType::match_expr(
+                    vec![
+                        (Expr::Any, Spec::from("b")),
+                        (Expr::Os(vec!["windows".to_owned()]), Spec::from("a")),
+                    ],
+                    Some(Spec::from("c")),
+                )),
                 right: None,
             }],
         );
@@ -406,13 +403,10 @@ mod tests {
                         None,
                     ),
                 },
-                right: Some(Spec {
-                    string: None,
-                    spectype: SpecType::variant_expr(
-                        vec![Spec::from("gvim"), Spec::from("ed")],
-                        None,
-                    ),
-                }),
+                right: Some(Spec::from(SpecType::variant_expr(
+                    vec![Spec::from("gvim"), Spec::from("ed")],
+                    None,
+                ))),
             }],
         );
     }
@@ -473,16 +467,13 @@ mod tests {
                 TokType::Semicolon
             ],
             &[Entry {
-                left: Spec {
-                    string: None,
-                    spectype: SpecType::match_expr(
-                        vec![
-                            (Expr::Host(vec!["hexagon".to_owned()]), Spec::from("a")),
-                            (Expr::Os(vec!["macos".to_owned()]), Spec::from("b")),
-                        ],
-                        None,
-                    ),
-                },
+                left: Spec::from(SpecType::match_expr(
+                    vec![
+                        (Expr::Host(vec!["hexagon".to_owned()]), Spec::from("a")),
+                        (Expr::Os(vec!["macos".to_owned()]), Spec::from("b")),
+                    ],
+                    None,
+                )),
                 right: None,
             }],
         )
@@ -501,10 +492,7 @@ mod tests {
                 TokType::Semicolon
             ],
             &[Entry {
-                left: Spec {
-                    string: None,
-                    spectype: SpecType::variant_expr(vec![Spec::from("a")], None),
-                },
+                left: Spec::from(SpecType::variant_expr(vec![Spec::from("a")], None)),
                 right: None,
             }],
         )
@@ -529,16 +517,13 @@ mod tests {
                 TokType::Semicolon
             ],
             &[Entry {
-                left: Spec {
-                    string: None,
-                    spectype: SpecType::match_expr(
-                        vec![(
-                            Expr::Os(vec!["linux".to_owned(), "windows".to_owned()]),
-                            Spec::from("a"),
-                        )],
-                        None,
-                    ),
-                },
+                left: Spec::from(SpecType::match_expr(
+                    vec![(
+                        Expr::Os(vec!["linux".to_owned(), "windows".to_owned()]),
+                        Spec::from("a"),
+                    )],
+                    None,
+                )),
                 right: None,
             }],
         )

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -253,6 +253,8 @@ impl SimpleParse for Expr {
             }) => match s.as_str() {
                 "os" => expr_type = Expr::Os,
                 "host" => expr_type = Expr::Host,
+                "!os" => expr_type = Expr::NotOs,
+                "!host" => expr_type = Expr::NotHost,
                 "default" => {
                     // "default" takes no strings to check (since it's always true).
                     iter.next();

--- a/src/config/strgen.rs
+++ b/src/config/strgen.rs
@@ -279,13 +279,20 @@ impl MatchExpr {
 mod tests {
     use super::*;
 
+    use lazy_static::lazy_static;
+
     fn results_in(spec: Spec, expected: Vec<&str>) {
         let yielded: Vec<_> = spec.into_iter().collect();
         assert_eq!(yielded, expected);
     }
 
-    fn incorrect_os() -> String {
-        if cfg!(windows) { "linux" } else { "windows" }.to_owned()
+    lazy_static! {
+        static ref HOSTNAME: String = hostname::get().unwrap().into_string().unwrap();
+        // Ensure that `NOT_HOSTNAME` contains a hostname that isn't equal to `HOSTNAME`.
+        static ref NOT_HOSTNAME: String = if HOSTNAME.clone().is_empty() { "hostname" } else { "" }.to_owned();
+        static ref OS : String = std::env::consts::OS.to_owned();
+        static ref NOT_OS: String =
+            if cfg!(windows) { "linux" } else { "windows" }.to_owned();
     }
 
     #[test]
@@ -301,7 +308,7 @@ mod tests {
                 spectype: SpecType::variant_expr(vec![Spec::from("b"), Spec::from("c")], None),
             },
             vec!["ab", "ac"],
-        );
+        )
     }
 
     #[test]
@@ -312,7 +319,7 @@ mod tests {
                 string: Some("d".to_owned()),
                 spectype: SpecType::match_expr(
                     vec![
-                        (Expr::Os(vec![incorrect_os()]), Spec::from("g")),
+                        (Expr::Os(vec![NOT_OS.clone()]), Spec::from("g")),
                         (Expr::Any, Spec::from("e")),
                     ],
                     Some(Spec::from("f")),
@@ -329,30 +336,24 @@ mod tests {
             Spec {
                 string: Some("d".to_owned()),
                 spectype: SpecType::match_expr(
-                    vec![(Expr::Os(vec![incorrect_os()]), Spec::from("g"))],
+                    vec![(Expr::Os(vec![NOT_OS.clone()]), Spec::from("g"))],
                     Some(Spec::from("f")),
                 ),
             },
             // Since the MatchExpr can't resolve to anything,
             // there is nothing here.
             // (At least, if the test _succeeds_.)
-            Vec::new(),
+            vec![],
         )
     }
 
     #[test]
     fn hostname_match() {
         results_in(
-            Spec {
-                string: None,
-                spectype: SpecType::match_expr(
-                    vec![(
-                        Expr::Host(vec![hostname::get().unwrap().into_string().unwrap()]),
-                        Spec::from("a"),
-                    )],
-                    None,
-                ),
-            },
+            Spec::from(SpecType::match_expr(
+                vec![(Expr::Host(vec![HOSTNAME.clone()]), Spec::from("a"))],
+                None,
+            )),
             // It will always resolve,
             // because it has the same hostname.
             vec!["a"],
@@ -362,33 +363,55 @@ mod tests {
     #[test]
     fn not_hostname_match() {
         results_in(
-            Spec {
-                string: None,
-                spectype: SpecType::match_expr(
-                    vec![(
-                        Expr::NotHost(vec![hostname::get().unwrap().into_string().unwrap()]),
-                        Spec::from("a"),
-                    )],
-                    None,
-                ),
-            },
-            // Since the value of NotHost is the fetched hostname, no spec should be resolved.
-            Vec::new(),
+            Spec::from(SpecType::match_expr(
+                vec![(Expr::NotHost(vec![NOT_HOSTNAME.clone()]), Spec::from("a"))],
+                None,
+            )),
+            vec!["a"],
+        )
+    }
+
+    #[test]
+    fn not_hostname_multiple_match() {
+        // Get hostname that is different to `HOSTNAME`.
+        results_in(
+            Spec::from(SpecType::match_expr(
+                vec![(
+                    Expr::NotHost(vec![NOT_HOSTNAME.clone(), HOSTNAME.clone()]),
+                    Spec::from("a"),
+                )],
+                None,
+            )),
+            // Expect nothing to be resolved as all hostnames given in !host should not match.
+            vec![],
         )
     }
 
     #[test]
     fn not_os_match() {
         results_in(
-            Spec {
-                string: None,
-                spectype: SpecType::match_expr(
-                    vec![(Expr::NotOs(vec![incorrect_os()]), Spec::from("a"))],
-                    None,
-                ),
-            },
+            Spec::from(SpecType::match_expr(
+                vec![(Expr::NotOs(vec![NOT_OS.clone()]), Spec::from("a"))],
+                None,
+            )),
             // The os given to NotOs is an incorrect_os which means it should resolve.
             vec!["a"],
+        )
+    }
+
+    #[test]
+    fn not_os_multiple_match() {
+        results_in(
+            Spec::from(SpecType::match_expr(
+                vec![(
+                    Expr::NotOs(vec![NOT_OS.clone(), OS.clone()]),
+                    Spec::from("a"),
+                )],
+                None,
+            )),
+            // Expect nothing as actual OS is given as NotOs.
+            // Multiple NotOs should mean that none of the given OS match.
+            vec![],
         )
     }
 
@@ -440,25 +463,16 @@ mod tests {
         let res_vec_str = res_vec.iter().map(|x| x.as_str()).collect();
         results_in(
             // Equivalent to `[a,b,c][d,e,f][g,h,i]`.
-            Spec {
-                string: None,
-                spectype: SpecType::variant_expr(
-                    vec![Spec::from("a"), Spec::from("b"), Spec::from("c")],
-                    Some(Spec {
-                        spectype: SpecType::variant_expr(
-                            vec![Spec::from("d"), Spec::from("e"), Spec::from("f")],
-                            Some(Spec {
-                                string: None,
-                                spectype: SpecType::variant_expr(
-                                    vec![Spec::from("g"), Spec::from("h"), Spec::from("i")],
-                                    None,
-                                ),
-                            }),
-                        ),
-                        string: None,
-                    }),
-                ),
-            },
+            Spec::from(SpecType::variant_expr(
+                vec![Spec::from("a"), Spec::from("b"), Spec::from("c")],
+                Some(Spec::from(SpecType::variant_expr(
+                    vec![Spec::from("d"), Spec::from("e"), Spec::from("f")],
+                    Some(Spec::from(SpecType::variant_expr(
+                        vec![Spec::from("g"), Spec::from("h"), Spec::from("i")],
+                        None,
+                    ))),
+                ))),
+            )),
             res_vec_str,
         );
     }


### PR DESCRIPTION
This PR implements `Expr::NotOs` and `Expr::NotHost`. In the configuration, these are invoked by `!os` and `!host` respectively. These expressions are evaluated as true if the os/hostname given is not present.

The `incorrect_os()` function was slightly refactored to return an incorrect os as a `String` to generalize its use across multiple unit test functions.

Unit tests have been added to ensure correct functionality of `Expr::NotOs` and `Expr::NotHost` expressions.