### PR TITLE
feat: add -m flag to sync

### DIFF
--- a/src/bin/ambit/cmd.rs
+++ b/src/bin/ambit/cmd.rs
@@ -84,7 +84,7 @@ pub fn sync(dry_run: bool, quiet: bool, move_files: bool) -> AmbitResult<()> {
         ));
     }
     let mut successful_syncs: usize = 0; // Number of syncs that actually occurred
-    let mut total_symlinks: usize = 0;
+    let mut total_syncs: usize = 0;
     let mut link = |repo_filename: &str, host_filename: &str| -> AmbitResult<()> {
         let host_file = AmbitPath::new(
             AMBIT_PATHS.home.path.join(host_filename),
@@ -167,7 +167,7 @@ pub fn sync(dry_run: bool, quiet: bool, move_files: bool) -> AmbitResult<()> {
                 );
             }
         }
-        total_symlinks += 1;
+        total_syncs += 1;
         Ok(())
     };
     let entries = get_config_entries()?;
@@ -193,9 +193,9 @@ pub fn sync(dry_run: bool, quiet: bool, move_files: bool) -> AmbitResult<()> {
     // Report the number of files symlinked
     println!(
         "sync result ({} total): {} synced; {} ignored",
-        total_symlinks,
+        total_syncs,
         successful_syncs,
-        total_symlinks - successful_syncs,
+        total_syncs - successful_syncs,
     );
     Ok(())
 }

--- a/src/bin/ambit/main.rs
+++ b/src/bin/ambit/main.rs
@@ -53,8 +53,8 @@ fn get_app() -> App<'static, 'static> {
                     Arg::with_name("move")
                         .long("move")
                         .short("m")
-                        .help("Automatically move config files into repo")
-                        .long_help("Will automatically move config files into repository (as well as symlinking them normally) if they aren't already symlinks into the repo."),
+                        .help("Move host files into dotfile repository if needed")
+                        .long_help("Will automatically move host files into repository if they don't already exist in the repository and then symlink them"),
                 ),
         )
         .subcommand(SubCommand::with_name("check").about("Check ambit configuration for errors"))

--- a/src/bin/ambit/main.rs
+++ b/src/bin/ambit/main.rs
@@ -48,6 +48,13 @@ fn get_app() -> App<'static, 'static> {
                         .long("quiet")
                         .short("q")
                         .help("Don't report individual symlinks"),
+                )
+                .arg(
+                    Arg::with_name("move")
+                        .long("move")
+                        .short("m")
+                        .help("Automatically move config files into repo")
+                        .long_help("Will automatically move config files into repository (as well as symlinking them normally) if they aren't already symlinks into the repo."),
                 ),
         )
         .subcommand(SubCommand::with_name("check").about("Check ambit configuration for errors"))
@@ -72,7 +79,8 @@ fn run() -> AmbitResult<()> {
     } else if let Some(matches) = matches.subcommand_matches("sync") {
         let dry_run = matches.is_present("dry-run");
         let quiet = matches.is_present("quiet");
-        cmd::sync(dry_run, quiet)?;
+        let move_files = matches.is_present("move");
+        cmd::sync(dry_run, quiet, move_files)?;
     }
     Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,7 @@ pub enum AmbitError {
         path: PathBuf,
         error: io::Error,
     },
-    Symlink {
+    Sync {
         host_file_path: PathBuf,
         repo_file_path: PathBuf,
         error: Box<AmbitError>,
@@ -35,7 +35,7 @@ impl Error for AmbitError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             AmbitError::File { error, .. } => Some(error),
-            AmbitError::Symlink { error, .. } => Some(error),
+            AmbitError::Sync { error, .. } => Some(error),
             _ => None,
         }
     }
@@ -49,7 +49,7 @@ impl Display for AmbitError {
             AmbitError::File { path, .. } => {
                 f.write_fmt(format_args!("File error with `{}`", path.display()))
             }
-            AmbitError::Symlink {
+            AmbitError::Sync {
                 repo_file_path,
                 host_file_path,
                 ..
@@ -119,7 +119,7 @@ Caused by:
 
     #[test]
     fn display_symlink() {
-        let err = AmbitError::Symlink {
+        let err = AmbitError::Sync {
             host_file_path: PathBuf::from("host"),
             repo_file_path: PathBuf::from("repo"),
             error: Box::new(AmbitError::Other("Error message".to_owned())),


### PR DESCRIPTION
The `-m` flag on the `sync` command moves config files into the repo if they already exist in their original location.