### PR TITLE
fix: create configuration directory on initialize

### DIFF
--- a/src/bin/ambit/directories.rs
+++ b/src/bin/ambit/directories.rs
@@ -69,6 +69,9 @@ impl AmbitPath {
     pub fn create(&self) -> AmbitResult<()> {
         match self.kind {
             AmbitPathKind::File => {
+                if let Some(parent) = &self.path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
                 File::create(&self.path)?;
             }
             AmbitPathKind::Directory => {

--- a/src/bin/ambit/directories.rs
+++ b/src/bin/ambit/directories.rs
@@ -32,6 +32,13 @@ impl AmbitPath {
         }
     }
 
+    pub fn ensure_parent_dirs_exist(&self) -> AmbitResult<()> {
+        if let Some(parent) = &self.path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        Ok(())
+    }
+
     pub fn to_str(&self) -> AmbitResult<&str> {
         // Converts path to string slice representation
         let result = self.path.to_str();
@@ -69,9 +76,6 @@ impl AmbitPath {
     pub fn create(&self) -> AmbitResult<()> {
         match self.kind {
             AmbitPathKind::File => {
-                if let Some(parent) = &self.path.parent() {
-                    fs::create_dir_all(parent)?;
-                }
                 File::create(&self.path)?;
             }
             AmbitPathKind::Directory => {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,7 +2,7 @@ use assert_cmd::{assert::Assert, Command};
 use std::{
     ffi::OsStr,
     fs::{self, File},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 use tempfile::TempDir;
 
@@ -109,6 +109,19 @@ fn init_force_overwrites() {
     AmbitTester::default()
         .with_default_paths()
         .args(vec!["init", "-f"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn init_ambit_config_dir_does_not_exist() {
+    // Ensure that temp_dir configuration directory is created when init is called.
+    let temp_dir = TempDir::new().unwrap();
+    // temp_path is equal to temp_dir path which is then removed.
+    let temp_path = Path::new(temp_dir.path());
+    fs::remove_dir(temp_path).unwrap();
+    AmbitTester::from_temp_dir(&temp_dir)
+        .arg("init")
         .assert()
         .success();
 }


### PR DESCRIPTION
This PR aims to make getting started with ambit easier. Before this PR, by default, if the `~/.config/ambit` directory didn't exist when `ambit init` or `ambit clone` is invoked, an error will occur:

```
ERROR: No such file or directory (os error 2)
```

This PR aims to fix this by ensuring that the parent directory of any file that is created through `AmbitPath` exists.

An additional integration test was added called `init_ambit_config_dir_does_not_exist` to ensure that this behavior works.

NOTE: The second commit in this PR, 39630d2, introduces better integration of the `ensure_parent_dirs_exist` function. This makes the solution of the initial problem to simply create the configuration file's parent directories before the file itself is created.