### PR TITLE
feat: implement clean command

### DIFF
--- a/src/bin/ambit/cmd.rs
+++ b/src/bin/ambit/cmd.rs
@@ -43,14 +43,14 @@ fn get_config_entries() -> AmbitResult<Vec<Entry>> {
         .map_err(AmbitError::Parse)
 }
 
-// Returns if a is symlinked to b (a -> b).
-fn is_symlinked(a: &PathBuf, b: &PathBuf) -> bool {
-    fs::read_link(a)
-        .map(|link_path| link_path == *b)
+// Return if target is symlinked to source (target -> source).
+fn is_symlinked(target: &PathBuf, source: &PathBuf) -> bool {
+    fs::read_link(target)
+        .map(|link_path| link_path == *source)
         .unwrap_or(false)
 }
 
-// Return iterator over path pairs from given entry.
+// Return iterator over path pairs in the form of `(repo_file, host_file)` from given entry.
 fn get_ambit_paths_from_entry<'a>(
     entry: &'a Entry,
 ) -> Box<dyn Iterator<Item = (AmbitPath, AmbitPath)> + 'a> {

--- a/src/bin/ambit/cmd.rs
+++ b/src/bin/ambit/cmd.rs
@@ -43,10 +43,10 @@ fn get_config_entries() -> AmbitResult<Vec<Entry>> {
         .map_err(AmbitError::Parse)
 }
 
-// Return if target is symlinked to source (target -> source).
-fn is_symlinked(target: &PathBuf, source: &PathBuf) -> bool {
-    fs::read_link(target)
-        .map(|link_path| link_path == *source)
+// Return if link_name is symlinked to target (link_name -> target).
+fn is_symlinked(link_name: &PathBuf, target: &PathBuf) -> bool {
+    fs::read_link(link_name)
+        .map(|link_path| link_path == *target)
         .unwrap_or(false)
 }
 

--- a/src/bin/ambit/main.rs
+++ b/src/bin/ambit/main.rs
@@ -57,6 +57,10 @@ fn get_app() -> App<'static, 'static> {
                         .long_help("Will automatically move host files into repository if they don't already exist in the repository and then symlink them"),
                 ),
         )
+        .subcommand(
+            SubCommand::with_name("clean")
+            .about("Remove all symlinks and delete host files")
+        )
         .subcommand(SubCommand::with_name("check").about("Check ambit configuration for errors"))
 }
 
@@ -81,6 +85,8 @@ fn run() -> AmbitResult<()> {
         let quiet = matches.is_present("quiet");
         let move_files = matches.is_present("move");
         cmd::sync(dry_run, quiet, move_files)?;
+    } else if matches.is_present("clean") {
+        cmd::clean()?;
     }
     Ok(())
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -242,6 +242,7 @@ fn sync_creates_host_parent_directories() {
 #[test]
 fn clean_after_sync() {
     let temp_dir = TempDir::new().unwrap();
+    let host_path = temp_dir.path().join("host.txt");
     AmbitTester::from_temp_dir(&temp_dir)
         .with_default_paths()
         .with_repo_file("repo.txt")
@@ -249,11 +250,13 @@ fn clean_after_sync() {
         .arg("sync")
         .assert()
         .success();
+    // host.txt should exist after sync.
+    assert!(host_path.exists());
     AmbitTester::from_temp_dir(&temp_dir)
         .with_config("repo.txt => host.txt;")
         .arg("clean")
         .assert()
         .success();
-    // host.txt should be deleted
-    assert!(!temp_dir.path().join("host.txt").exists());
+    // host.txt should be deleted after clean.
+    assert!(!host_path.exists());
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -260,3 +260,27 @@ fn clean_after_sync() {
     // host.txt should be deleted after clean.
     assert!(!host_path.exists());
 }
+
+#[test]
+fn clean_ignores_parent_directories() {
+    let temp_dir = TempDir::new().unwrap();
+    let host_file_directory = temp_dir.path().join("a").join("b");
+    AmbitTester::from_temp_dir(&temp_dir)
+        .with_default_paths()
+        .with_repo_file("repo.txt")
+        .with_config("repo.txt => a/b/host.txt;")
+        .arg("sync")
+        .assert()
+        .success();
+    // a/b/host.txt should exist after sync.
+    assert!(host_file_directory.join("host.txt").exists());
+    AmbitTester::from_temp_dir(&temp_dir)
+        .with_config("repo.txt => a/b/host.txt;")
+        .arg("clean")
+        .assert()
+        .success();
+    // a/b/host.txt should be deleted after clean.
+    assert!(!host_file_directory.join("host.txt").exists());
+    // a/b path should still exist after clean although it was created from sync invocation.
+    assert!(host_file_directory.exists());
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -238,3 +238,22 @@ fn sync_creates_host_parent_directories() {
         temp_dir.path().join("repo").join("repo.txt"),
     ));
 }
+
+#[test]
+fn clean_after_sync() {
+    let temp_dir = TempDir::new().unwrap();
+    AmbitTester::from_temp_dir(&temp_dir)
+        .with_default_paths()
+        .with_repo_file("repo.txt")
+        .with_config("repo.txt => host.txt;")
+        .arg("sync")
+        .assert()
+        .success();
+    AmbitTester::from_temp_dir(&temp_dir)
+        .with_config("repo.txt => host.txt;")
+        .arg("clean")
+        .assert()
+        .success();
+    // host.txt should be deleted
+    assert!(!temp_dir.path().join("host.txt").exists());
+}


### PR DESCRIPTION
This PR implements the `clean` command invoked with `$ ambit clean`. This command has description `Remove all symlinks and delete host files`. Essentially, it reads the configuration, iterates through the entries, and deletes its host file (effectively removing the symlink). A host file will only be deleted if it is appropriate symlinked to the repo file.

Implementation-wise, the entry iteration logic has been vastly simplified for both `sync` and `clean` functions in `cmd.rs`.

An integration has been added to test `clean` functionality.