### PR TITLE
feat: implement use-repo-config sync option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ clap = "2.33.3"
 dirs = "3.0.1"
 hostname = "0.3.1"
 lazy_static = "1.4.0"
+walkdir = "2.3.1"
 
 [dev-dependencies]
 assert_cmd = "1.0.3"

--- a/src/bin/ambit/cmd.rs
+++ b/src/bin/ambit/cmd.rs
@@ -207,15 +207,18 @@ pub fn sync(
         if !use_repo_config {
             // Ask user if they want to search for repo config.
             println!(
-                "No configuration file in {}",
+                "No configuration file found in {}",
                 AMBIT_PATHS.config.path.display()
             );
-            print!("Search for configuration in repository? [y/n]: ");
+            print!("Search for configuration in repository? [Y/n] ");
+            io::stdout().flush()?;
             let mut answer = String::new();
             io::stdin().read_line(&mut answer)?;
-            if answer.to_lowercase() != "y" {
-                println!("Cancelling sync...");
-                return Ok(());
+            if let Some(answer) = answer.chars().next() {
+                if answer.to_lowercase().to_string() != "y" {
+                    println!("Cancelling sync...");
+                    return Ok(());
+                }
             }
         }
         println!(

--- a/src/bin/ambit/cmd.rs
+++ b/src/bin/ambit/cmd.rs
@@ -97,11 +97,7 @@ fn prompt_confirm(message: &str) -> AmbitResult<bool> {
     io::stdout().flush()?;
     let mut answer = String::new();
     io::stdin().read_line(&mut answer)?;
-    if answer.trim().to_lowercase() == "y" {
-        Ok(true)
-    } else {
-        Ok(false)
-    }
+    Ok(answer.trim().to_lowercase() == "y")
 }
 
 // Initialize an empty dotfile repository

--- a/src/bin/ambit/directories.rs
+++ b/src/bin/ambit/directories.rs
@@ -8,6 +8,8 @@ use std::{
 
 use ambit::error::{AmbitError, AmbitResult};
 
+pub const CONFIG_NAME: &str = "config.ambit";
+
 #[derive(PartialEq, Eq, Debug)]
 pub enum AmbitPathKind {
     File,
@@ -110,7 +112,7 @@ impl AmbitPaths {
         let configuration_path = home_path.join(".config/ambit");
 
         let config_path = AmbitPaths::get_path_from_env("AMBIT_CONFIG_PATH")
-            .unwrap_or_else(|| configuration_path.join("config.ambit"));
+            .unwrap_or_else(|| configuration_path.join(CONFIG_NAME));
 
         let repo_path = AmbitPaths::get_path_from_env("AMBIT_REPO_PATH")
             .unwrap_or_else(|| configuration_path.join("repo"));

--- a/src/bin/ambit/main.rs
+++ b/src/bin/ambit/main.rs
@@ -55,7 +55,12 @@ fn get_app() -> App<'static, 'static> {
                         .short("m")
                         .help("Move host files into dotfile repository if needed")
                         .long_help("Will automatically move host files into repository if they don't already exist in the repository and then symlink them"),
-                ),
+                )
+                .arg(
+                    Arg::with_name("use-repo-config")
+                    .long("use-repo-config")
+                    .help("Recursively search dotfile repository for configuration file and use it to sync")
+                )
         )
         .subcommand(
             SubCommand::with_name("clean")
@@ -84,7 +89,8 @@ fn run() -> AmbitResult<()> {
         let dry_run = matches.is_present("dry-run");
         let quiet = matches.is_present("quiet");
         let move_files = matches.is_present("move");
-        cmd::sync(dry_run, quiet, move_files)?;
+        let use_repo_config = matches.is_present("use-repo-config");
+        cmd::sync(dry_run, quiet, move_files, use_repo_config)?;
     } else if matches.is_present("clean") {
         cmd::clean()?;
     }

--- a/src/bin/ambit/main.rs
+++ b/src/bin/ambit/main.rs
@@ -61,6 +61,16 @@ fn get_app() -> App<'static, 'static> {
                     .long("use-repo-config")
                     .help("Recursively search dotfile repository for configuration file and use it to sync")
                 )
+                .arg(
+                    Arg::with_name("use-repo-config-if-required")
+                    .long("use-repo-config-if-required")
+                    .help("Search for configuration file in dotfile repository if configuration in default location does not exist")
+                )
+                .arg(
+                    Arg::with_name("use-any-repo-config-found")
+                    .long("use-any-repo-config-found")
+                    .help("Use first repository configuration found after recursive search")
+                )
         )
         .subcommand(
             SubCommand::with_name("clean")
@@ -90,7 +100,16 @@ fn run() -> AmbitResult<()> {
         let quiet = matches.is_present("quiet");
         let move_files = matches.is_present("move");
         let use_repo_config = matches.is_present("use-repo-config");
-        cmd::sync(dry_run, quiet, move_files, use_repo_config)?;
+        let use_repo_config_if_required = matches.is_present("use-repo-config-if-required");
+        let use_any_repo_config = matches.is_present("use-any-repo-config-found");
+        cmd::sync(
+            dry_run,
+            quiet,
+            move_files,
+            use_repo_config,
+            use_repo_config_if_required,
+            use_any_repo_config,
+        )?;
     } else if matches.is_present("clean") {
         cmd::clean()?;
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,7 @@ pub enum AmbitError {
     //       Future changes may result in a Vec<ParseError> being returned.
     //       This should be taken care of.
     Parse(config::ParseError),
+    WalkDir(walkdir::Error),
     // File error is encountered on failed file open operation
     // Provides additional path information
     File {
@@ -46,6 +47,7 @@ impl Display for AmbitError {
         match self {
             AmbitError::Io(ref e) => e.fmt(f),
             AmbitError::Parse(ref e) => e.fmt(f),
+            AmbitError::WalkDir(ref e) => e.fmt(f),
             AmbitError::File { path, .. } => {
                 f.write_fmt(format_args!("File error with `{}`", path.display()))
             }
@@ -71,6 +73,12 @@ impl Display for AmbitError {
 impl From<io::Error> for AmbitError {
     fn from(err: io::Error) -> AmbitError {
         AmbitError::Io(err)
+    }
+}
+
+impl From<walkdir::Error> for AmbitError {
+    fn from(err: walkdir::Error) -> AmbitError {
+        AmbitError::WalkDir(err)
     }
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -266,6 +266,7 @@ fn sync_use_repo_config_option() {
         .with_repo_file("repo.txt")
         .with_file_with_content(&repo_config_path, "repo.txt => host.txt;")
         .args(vec!["sync", "--use-repo-config"])
+        .write_stdin("Y") // 'Y' should be synonymous to 'y'
         .assert()
         .success();
     assert!(is_symlinked(
@@ -283,7 +284,10 @@ fn sync_with_missing_config_answer_yes() {
         .with_repo_file("repo.txt")
         .with_file_with_content(&repo_config_path, "repo.txt => host.txt;")
         .arg("sync")
-        .write_stdin("y")
+        // Answer 'y' twice:
+        // 1. Accept to search for configuration.
+        // 2. Accept to use repo config that was found.
+        .write_stdin("y\ny")
         .assert()
         .success();
     assert!(is_symlinked(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -354,6 +354,28 @@ fn sync_use_any_repo_config_found() {
 }
 
 #[test]
+fn sync_use_any_repo_config_found_if_required() {
+    let temp_dir = TempDir::new().unwrap();
+    let repo_path = temp_dir.path().join("repo");
+    AmbitTester::from_temp_dir(&temp_dir)
+        .with_repo_file("repo.txt")
+        .with_file_with_content(&repo_path.join("config.ambit"), "repo.txt => host.txt;")
+        // Combine flags --use-any-repo-config-found and --use-repo-config-if-required.
+        // This should mean that nothing has to be written to stdin.
+        .args(vec![
+            "sync",
+            "--use-any-repo-config-found",
+            "--use-repo-config-if-required",
+        ])
+        .assert()
+        .success();
+    assert!(is_symlinked(
+        temp_dir.path().join("host.txt"),
+        temp_dir.path().join("repo").join("repo.txt"),
+    ));
+}
+
+#[test]
 fn clean_after_sync() {
     let temp_dir = TempDir::new().unwrap();
     let host_path = temp_dir.path().join("host.txt");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -37,14 +37,24 @@ impl AmbitTester {
 
     // Write content to configuration file.
     fn with_config(self, content: &str) -> Self {
-        fs::write(&self.config_path, content).expect("Unable to write to file");
+        File::create(&self.config_path).unwrap();
+        fs::write(&self.config_path, content).unwrap();
+        self
+    }
+
+    // Write content to a given path.
+    fn with_file_with_content(self, path: &PathBuf, content: &str) -> Self {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        File::create(&path).unwrap();
+        fs::write(&path, content).unwrap();
         self
     }
 
     // Create a custom file in repo_path directory. Mimics repo_file.
     fn with_repo_file(self, name: &str) -> Self {
-        File::create(self.repo_path.join(name)).unwrap();
-        self
+        let s = self.with_repo_path();
+        File::create(s.repo_path.join(name)).unwrap();
+        s
     }
 
     // Creates a custom file in home_path directory. Mimic host_file.
@@ -53,10 +63,8 @@ impl AmbitTester {
         self
     }
 
-    // Creates configuration file and repository directory with .git.
-    fn with_default_paths(self) -> Self {
+    fn with_repo_path(self) -> Self {
         fs::create_dir_all(&self.repo_path.join(".git")).unwrap();
-        File::create(&self.config_path).unwrap();
         self
     }
 
@@ -71,6 +79,14 @@ impl AmbitTester {
         S: AsRef<OsStr>,
     {
         self.executable.args(args);
+        self
+    }
+
+    fn write_stdin<S>(mut self, buffer: S) -> Self
+    where
+        S: Into<Vec<u8>>,
+    {
+        self.executable.write_stdin(buffer);
         self
     }
 
@@ -96,9 +112,9 @@ fn is_symlinked(a: PathBuf, b: PathBuf) -> bool {
 #[test]
 fn init_repo_already_exists() {
     // Expect an error when attempting to initialize without force flag.
-    // The repository directory is already created when calling `with_default_paths()`.
+    // The repository directory is already created when calling `with_repo_path()`.
     AmbitTester::default()
-        .with_default_paths()
+        .with_repo_path()
         .arg("init")
         .assert()
         .stderr("ERROR: Dotfile repository already exists.\nUse '-f' flag to overwrite.\n");
@@ -107,7 +123,7 @@ fn init_repo_already_exists() {
 #[test]
 fn init_force_overwrites() {
     AmbitTester::default()
-        .with_default_paths()
+        .with_repo_path()
         .args(vec!["init", "-f"])
         .assert()
         .success();
@@ -130,7 +146,7 @@ fn init_ambit_config_dir_does_not_exist() {
 fn clone_repo_already_exists() {
     // Expect an error when attempting to clone without force flag.
     AmbitTester::default()
-        .with_default_paths()
+        .with_repo_path()
         .args(vec!["clone", "https://github.com/plamorg/ambit"])
         .assert()
         .stderr("ERROR: Dotfile repository already exists.\nUse '-f' flag to overwrite.\n");
@@ -139,7 +155,7 @@ fn clone_repo_already_exists() {
 #[test]
 fn sync_without_repo() {
     // Error should occur if attempting to sync without initializing.
-    // `with_default_paths` is omitted here.
+    // `with_repo_path` is omitted here.
     AmbitTester::default().arg("sync").assert().stderr(
         "ERROR: Dotfile repository does not exist. Run `init` or `clone` before syncing.\n",
     );
@@ -150,7 +166,6 @@ fn sync_host_file_already_exists() {
     // The host file already exists but is not symlinked to repo file.
     let temp_dir = TempDir::new().unwrap();
     AmbitTester::from_temp_dir(&temp_dir)
-        .with_default_paths()
         .with_repo_file("repo.txt")
         .with_host_file("host.txt")
         .with_config("repo.txt => host.txt;")
@@ -163,7 +178,7 @@ fn sync_host_file_already_exists() {
 fn sync_repo_file_does_not_exist() {
     // Repo file should exist for sync to work.
     AmbitTester::default()
-        .with_default_paths()
+        .with_repo_path()
         .with_config("repo.txt => host.txt;")
         .arg("sync")
         .assert()
@@ -174,7 +189,6 @@ fn sync_repo_file_does_not_exist() {
 fn sync_normal() {
     let temp_dir = TempDir::new().unwrap();
     AmbitTester::from_temp_dir(&temp_dir)
-        .with_default_paths()
         .with_repo_file("repo.txt")
         .with_config("repo.txt => host.txt;")
         .arg("sync")
@@ -191,7 +205,7 @@ fn sync_normal() {
 fn sync_move_normal() {
     let temp_dir = TempDir::new().unwrap();
     AmbitTester::from_temp_dir(&temp_dir)
-        .with_default_paths()
+        .with_repo_path()
         .with_config("repo.txt => host.txt;")
         .with_host_file("host.txt")
         .args(vec!["sync", "-m"])
@@ -210,7 +224,6 @@ fn sync_move_normal() {
 fn sync_dry_run_should_not_symlink() {
     let temp_dir = TempDir::new().unwrap();
     AmbitTester::from_temp_dir(&temp_dir)
-        .with_default_paths()
         .with_repo_file("repo.txt")
         .with_config("repo.txt => should-not-exist.txt;")
         .args(vec!["sync", "--dry-run"])
@@ -226,7 +239,6 @@ fn sync_creates_host_parent_directories() {
     // We want to ensure that the following test does not fail due to "No such file or directory" error.
     let temp_dir = TempDir::new().unwrap();
     AmbitTester::from_temp_dir(&temp_dir)
-        .with_default_paths()
         .with_repo_file("repo.txt")
         .with_config("repo.txt => a/b/host.txt;")
         .arg("sync")
@@ -240,11 +252,70 @@ fn sync_creates_host_parent_directories() {
 }
 
 #[test]
+fn sync_use_repo_config_option() {
+    // If --use-repo-config flag is passed, recursively search for configuration in repository and use that.
+    let temp_dir = TempDir::new().unwrap();
+    // Set repo_config_path to /a/b/config.ambit to ensure recursive search works.
+    let repo_config_path = temp_dir
+        .path()
+        .join("repo")
+        .join("a")
+        .join("b")
+        .join("config.ambit");
+    AmbitTester::from_temp_dir(&temp_dir)
+        .with_repo_file("repo.txt")
+        .with_file_with_content(&repo_config_path, "repo.txt => host.txt;")
+        .args(vec!["sync", "--use-repo-config"])
+        .assert()
+        .success();
+    assert!(is_symlinked(
+        temp_dir.path().join("host.txt"),
+        temp_dir.path().join("repo").join("repo.txt"),
+    ));
+}
+
+#[test]
+fn sync_with_missing_config_answer_yes() {
+    // Sync without existing configuration file and answer yes to use repo configuration instead.
+    let temp_dir = TempDir::new().unwrap();
+    let repo_config_path = temp_dir.path().join("repo").join("config.ambit");
+    AmbitTester::from_temp_dir(&temp_dir)
+        .with_repo_file("repo.txt")
+        .with_file_with_content(&repo_config_path, "repo.txt => host.txt;")
+        .arg("sync")
+        .write_stdin("y")
+        .assert()
+        .success();
+    assert!(is_symlinked(
+        temp_dir.path().join("host.txt"),
+        temp_dir.path().join("repo").join("repo.txt"),
+    ));
+}
+
+#[test]
+fn sync_with_missing_config_answer_no() {
+    // Sync without existing configuration file but answer no to using repo configuration.
+    let temp_dir = TempDir::new().unwrap();
+    let repo_config_path = temp_dir.path().join("repo").join("config.ambit");
+    AmbitTester::from_temp_dir(&temp_dir)
+        .with_repo_file("repo.txt")
+        .with_file_with_content(&repo_config_path, "repo.txt => host.txt;")
+        .arg("sync")
+        .write_stdin("n")
+        .assert()
+        .success();
+    // Should not be symlinked.
+    assert!(!is_symlinked(
+        temp_dir.path().join("host.txt"),
+        temp_dir.path().join("repo").join("repo.txt"),
+    ));
+}
+
+#[test]
 fn clean_after_sync() {
     let temp_dir = TempDir::new().unwrap();
     let host_path = temp_dir.path().join("host.txt");
     AmbitTester::from_temp_dir(&temp_dir)
-        .with_default_paths()
         .with_repo_file("repo.txt")
         .with_config("repo.txt => host.txt;")
         .arg("sync")
@@ -266,7 +337,6 @@ fn clean_ignores_parent_directories() {
     let temp_dir = TempDir::new().unwrap();
     let host_file_directory = temp_dir.path().join("a").join("b");
     AmbitTester::from_temp_dir(&temp_dir)
-        .with_default_paths()
         .with_repo_file("repo.txt")
         .with_config("repo.txt => a/b/host.txt;")
         .arg("sync")


### PR DESCRIPTION
Implementation details:
* `walkdir` dependency added (`2.3.1`).
* New `AmbitError` variant `AmbitError::WalkDir`.
* Configuration file name has been defined as a global const variable.
* Integration test infrastructure has been refactored slightly to support the new tests and reduce repeated code:
  * `with_config` and `with_repo_file` ensures the creation of the config and repo file respectively.
  * `with_default_paths` has been refactored to `with_repo_path`, exact same functionality but doesn't create config file in the process.
  * `write_stdin` function introduced.