### PR TITLE
docs: add additional package information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "ambit"
+description = "Dotfile manager written in Rust."
+repository = "https://github.com/plamorg/ambit"
+homepage = "https://github.com/plamorg/ambit"
 version = "0.1.0"
 authors = ["Edward Wibowo <wibow9770@gmail.com>", "Vir Chaudhury <virchau13@mail.hexular.net>"]
 edition = "2018"
+license = "GPL-3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This PR adds some additional package information to `Cargo.toml` for easier integration with the AUR.