### PR TITLE
fix: take path rather than pathbuf as argument

### DIFF
--- a/src/bin/ambit/cmd.rs
+++ b/src/bin/ambit/cmd.rs
@@ -6,7 +6,7 @@ use std::os::windows::fs::symlink_file as symlink;
 use std::{
     fs,
     io::{self, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::Command,
 };
 
@@ -46,7 +46,7 @@ fn get_config_entries(config_path: &AmbitPath) -> AmbitResult<Vec<Entry>> {
 }
 
 // Return if link_name is symlinked to target (link_name -> target).
-fn is_symlinked(link_name: &PathBuf, target: &PathBuf) -> bool {
+fn is_symlinked(link_name: &Path, target: &Path) -> bool {
     fs::read_link(link_name)
         .map(|link_path| link_path == *target)
         .unwrap_or(false)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -43,7 +43,7 @@ impl AmbitTester {
     }
 
     // Write content to a given path.
-    fn with_file_with_content(self, path: &PathBuf, content: &str) -> Self {
+    fn with_file_with_content(self, path: &Path, content: &str) -> Self {
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         File::create(&path).unwrap();
         fs::write(&path, content).unwrap();


### PR DESCRIPTION
This PR fixes `clippy` warnings about using `&PathBuf` over `&Path`.