### PR TITLE
feat: allow multiple errors to be reported

### DIFF
--- a/src/config/lexer.rs
+++ b/src/config/lexer.rs
@@ -54,6 +54,7 @@ impl Token {
     }
 }
 
+#[derive(Debug)]
 pub struct Lexer<I: Iterator<Item = char>> {
     iter: Peekable<I>,
     line: usize,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -40,7 +40,7 @@ impl From<ParseErrorType> for ParseError {
     }
 }
 
-pub type ParseResult<T> = std::result::Result<T, ParseError>;
+pub type ParseResult<T> = Result<T, ParseError>;
 
 pub fn get_entries<I: Iterator<Item = char>>(char_iter: Peekable<I>) -> Parser<Lexer<I>> {
     let lex = Lexer::new(char_iter);

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,7 @@ pub enum AmbitError {
     // TODO: As of now, a single ParseError is returned from config::get_entries
     //       Future changes may result in a Vec<ParseError> being returned.
     //       This should be taken care of.
-    Parse(config::ParseError),
+    Parse(Vec<config::ParseError>),
     WalkDir(walkdir::Error),
     // File error is encountered on failed file open operation
     // Provides additional path information
@@ -46,7 +46,12 @@ impl Display for AmbitError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             AmbitError::Io(ref e) => e.fmt(f),
-            AmbitError::Parse(ref e) => e.fmt(f),
+            AmbitError::Parse(errors) => {
+                for e in errors.iter() {
+                    e.fmt(f)?;
+                }
+                Ok(())
+            }
             AmbitError::WalkDir(ref e) => e.fmt(f),
             AmbitError::File { path, .. } => {
                 f.write_fmt(format_args!("File error with `{}`", path.display()))


### PR DESCRIPTION
This PR implements the ability for multiple errors to be reported. Resolves #17.

**Implementation Details**

When an error is encountered when iterating through `Parser<I>`, a while loop is used to continue iterating through the tokens until an entry that isn't an error is found. This is explained in the comments as part of the initial commit:

```
// If an error has been encountered, continue iterating until a non-error entry is found.
// Contiguous errors are a by-product of the initial error and shouldn't be reported.
```

A unit test has been added to test and demonstrate this functionality.

Note: No functionality to format parse errors has been implemented in this PR; however, this will be done if needed (perhaps in this PR?).