### PR TITLE
feat: implement pattern matching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ dirs = "3.0.1"
 hostname = "0.3.1"
 lazy_static = "1.4.0"
 walkdir = "2.3.1"
-patmatch = "0.1.2"
+patmatch = "0.1.3"
 
 [dev-dependencies]
 assert_cmd = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ dirs = "3.0.1"
 hostname = "0.3.1"
 lazy_static = "1.4.0"
 walkdir = "2.3.1"
+patmatch = "0.1.2"
 
 [dev-dependencies]
 assert_cmd = "1.0.3"

--- a/src/bin/ambit/cmd.rs
+++ b/src/bin/ambit/cmd.rs
@@ -50,7 +50,7 @@ fn get_config_entries(config_path: &AmbitPath) -> AmbitResult<Vec<Entry>> {
 fn is_symlinked(link_name: &Path, target: &Path) -> bool {
     fs::read_link(link_name)
         .map(|link_path| link_path == *target)
-        .is_ok()
+        .unwrap_or(false)
 }
 
 // Return a vector of PathBufs that match a pattern relative to the given start_path.
@@ -65,9 +65,9 @@ fn get_paths_from_spec(spec: &Spec, start_path: PathBuf) -> AmbitResult<Vec<Path
             // The only valid path at the start is the starting path.
             // This will be replaced at every iteration/depth.
             let mut valid_paths: Vec<PathBuf> = vec![start_path.clone()];
-            let components: Vec<String> = Path::new(&entry)
+            let components: Vec<_> = Path::new(&entry)
                 .components()
-                .map(|comp| comp.as_os_str().to_string_lossy().to_string())
+                .map(|comp| comp.as_os_str().to_string_lossy())
                 .collect();
             // To find matching files and directories, an entry as part of the spec is split into components.
             // For each component, a pattern is compiled and a vector of paths that match this pattern is found.
@@ -93,7 +93,7 @@ fn get_paths_from_spec(spec: &Spec, start_path: PathBuf) -> AmbitResult<Vec<Path
                             if match expected_path_kind {
                                 AmbitPathKind::File => path.is_file(),
                                 AmbitPathKind::Directory => path.is_dir(),
-                            } && pattern.matches(&file_name.to_string_lossy().to_string())
+                            } && pattern.matches(&file_name.to_string_lossy())
                             {
                                 new_valid_paths.push(path);
                             }

--- a/src/bin/ambit/cmd.rs
+++ b/src/bin/ambit/cmd.rs
@@ -50,42 +50,28 @@ fn get_config_entries(config_path: &AmbitPath) -> AmbitResult<Vec<Entry>> {
 fn is_symlinked(link_name: &Path, target: &Path) -> bool {
     fs::read_link(link_name)
         .map(|link_path| link_path == *target)
-        .unwrap_or(false)
+        .is_ok()
 }
 
+// Retrieves paths from a spec and expands pattern matching characters relative to given start_path.
 fn get_paths_from_spec(spec: &Spec, start_path: PathBuf) -> AmbitResult<Vec<PathBuf>> {
     let mut paths: Vec<PathBuf> = Vec::new();
-    let contains_pattern_char = |s: &str| -> bool { s.contains('*') || s.contains('?') };
     for entry in spec.into_iter() {
-        if contains_pattern_char(&entry) {
-            fn get_matches(
-                ancestor_path: &Path,
-                expected_path_kind: &AmbitPathKind,
-                does_match: impl Fn(&str) -> bool,
-            ) -> AmbitResult<Vec<PathBuf>> {
-                let mut matches = Vec::new();
-                // Iterate through all entries in ancestor_path.
-                for path in fs::read_dir(ancestor_path)? {
-                    let path = path?.path();
-                    // Validify the current path.
-                    if let Some(file_name) = path.file_name() {
-                        if match expected_path_kind {
-                            AmbitPathKind::File => path.is_file(),
-                            AmbitPathKind::Directory => path.is_dir(),
-                        } && does_match(&file_name.to_string_lossy().to_string())
-                        {
-                            matches.push(path);
-                        }
-                    }
-                }
-                Ok(matches)
-            }
+        if !entry.contains('*') && !entry.contains('?') {
+            // The entry does not contain any pattern matching characters.
+            // This is a definitive path so we can simply push it.
+            paths.push(PathBuf::from(&entry));
+        } else {
             // The only valid path at the start is the starting path.
+            // This will be replaced at every iteration/depth.
             let mut valid_paths: Vec<PathBuf> = vec![start_path.clone()];
             let components: Vec<String> = Path::new(&entry)
                 .components()
                 .map(|comp| comp.as_os_str().to_string_lossy().to_string())
                 .collect();
+            // To find matching files and directories, an entry as part of the spec is split into components.
+            // For each component, a pattern is compiled and a vector of paths that match this pattern is found.
+            // With the vector produced from the previous component, the process is repeated with the ancestor paths equal to the said vector.
             for (i, component) in components.iter().enumerate() {
                 let mut new_valid_paths: Vec<PathBuf> = Vec::new();
                 let expected_path_kind = if i < components.len() - 1 {
@@ -99,25 +85,27 @@ fn get_paths_from_spec(spec: &Spec, start_path: PathBuf) -> AmbitResult<Vec<Path
                     &component,
                     MatchOptions::WILDCARDS | MatchOptions::UNKNOWN_CHARS,
                 );
-                for path in &valid_paths {
-                    new_valid_paths.append(&mut get_matches(
-                        &path,
-                        &expected_path_kind,
-                        |name: &str| -> bool { pattern.matches(name) },
-                    )?);
+                for ancestor_path in &valid_paths {
+                    for path in fs::read_dir(ancestor_path)? {
+                        let path = path?.path();
+                        // Validify the current path.
+                        if let Some(file_name) = path.file_name() {
+                            if match expected_path_kind {
+                                AmbitPathKind::File => path.is_file(),
+                                AmbitPathKind::Directory => path.is_dir(),
+                            } && pattern.matches(&file_name.to_string_lossy().to_string())
+                            {
+                                new_valid_paths.push(path);
+                            }
+                        }
+                    }
                 }
                 valid_paths = new_valid_paths;
             }
             // Strip prefix from all paths.
-            valid_paths = valid_paths
-                .iter()
-                .map(|path| -> AmbitResult<PathBuf> {
-                    Ok(path.strip_prefix(&start_path)?.to_path_buf())
-                })
-                .collect::<AmbitResult<Vec<PathBuf>>>()?;
-            paths.append(&mut valid_paths);
-        } else {
-            paths.push(PathBuf::from(&entry));
+            for path in valid_paths {
+                paths.push(path.strip_prefix(&start_path)?.to_path_buf());
+            }
         }
     }
     Ok(paths)
@@ -125,22 +113,23 @@ fn get_paths_from_spec(spec: &Spec, start_path: PathBuf) -> AmbitResult<Vec<Path
 
 // Return iterator over path pairs in the form of `(repo_file, host_file)` from given entry.
 fn get_ambit_paths_from_entry(entry: &Entry) -> AmbitResult<Vec<(AmbitPath, AmbitPath)>> {
+    let left_entry_start = if entry.right.is_some() {
+        PathBuf::from(AMBIT_PATHS.repo.to_str()?)
+    } else {
+        PathBuf::from(AMBIT_PATHS.home.to_str()?)
+    };
     let (left_paths, right_paths): (Vec<PathBuf>, Option<Vec<PathBuf>>) =
-        if let Some(entry_right) = &entry.right {
-            (
-                get_paths_from_spec(&entry.left, PathBuf::from(AMBIT_PATHS.repo.to_str()?))?,
+        (get_paths_from_spec(&entry.left, left_entry_start)?, {
+            if let Some(entry_right) = &entry.right {
                 Some(get_paths_from_spec(
                     &entry_right,
                     PathBuf::from(AMBIT_PATHS.home.to_str()?),
-                )?),
-            )
-        } else {
-            // The right entry does not exist. Treat the left entry as both the repo and host paths.
-            (
-                get_paths_from_spec(&entry.left, PathBuf::from(AMBIT_PATHS.home.to_str()?))?,
-                None,
-            )
-        };
+                )?)
+            } else {
+                // The right entry does not exist. Treat the left entry as both the repo and host paths.
+                None
+            }
+        });
     // The number of left and right paths may be different due to pattern matching.
     // An error is thrown if they have different sizes.
     if let Some(right_paths) = &right_paths {
@@ -154,21 +143,24 @@ fn get_ambit_paths_from_entry(entry: &Entry) -> AmbitResult<Vec<(AmbitPath, Ambi
                     .join("\n")
             };
             return Err(AmbitError::Other(format!(
-                "Entry has imbalanced left and right side due to pattern matching\nAttempted to sync:\n{}\nWITH:\n{}",
+                "Entry has imbalanced left and right side due to pattern matching\nAttempted to sync:\n{}\nwith:\n{}",
                 format_paths(&left_paths), format_paths(right_paths),
             )));
         }
     }
-    Ok(left_paths
-        .iter()
-        .zip(right_paths.unwrap_or_else(|| left_paths.clone()).iter())
-        .map(|(repo_path, host_path)| {
-            (
-                AmbitPath::new(AMBIT_PATHS.repo.path.join(repo_path), AmbitPathKind::File),
-                AmbitPath::new(AMBIT_PATHS.home.path.join(host_path), AmbitPathKind::File),
-            )
-        })
-        .collect())
+    let mut paths = Vec::new();
+    for (i, repo_path) in left_paths.iter().enumerate() {
+        let host_path = if let Some(ref right_paths) = right_paths {
+            &right_paths[i]
+        } else {
+            repo_path
+        };
+        paths.push((
+            AmbitPath::new(AMBIT_PATHS.repo.path.join(repo_path), AmbitPathKind::File),
+            AmbitPath::new(AMBIT_PATHS.home.path.join(host_path), AmbitPathKind::File),
+        ))
+    }
+    Ok(paths)
 }
 
 // Recursively search dotfile repository for config path.
@@ -450,6 +442,15 @@ mod tests {
             &["c/b/a", "a/b/c"],
             &[PathBuf::from("a").join("b").join("c")],
         );
+    }
+
+    #[test]
+    fn get_paths_from_spec_ignore_parent() {
+        // This will resolve to a/b/c because if the user explicitly specifies a file (without pattern matching characters)
+        // its existence has to be verified at the symlinking stage which would error if it doesn't exist.
+        // This is to inform the user that the file does not exist.
+        // This differs from a pattern matching spec that will not resolve if the file does not exist.
+        test_spec("a/b/c", &["a/b"], &[PathBuf::from("a").join("b").join("c")]);
     }
 
     #[test]

--- a/src/bin/ambit/cmd.rs
+++ b/src/bin/ambit/cmd.rs
@@ -491,6 +491,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn get_paths_from_spec_with_escaped_char() {
         test_spec("x\\*y", &["x*y", "xay", "xaay"], &[PathBuf::from("x*y")]);

--- a/src/config/ast.rs
+++ b/src/config/ast.rs
@@ -37,17 +37,9 @@ impl Spec {
         }
     }
 }
-impl From<String> for Spec {
-    fn from(s: String) -> Self {
-        Spec {
-            string: Some(s),
-            spectype: SpecType::None,
-        }
-    }
-}
 impl From<&str> for Spec {
     fn from(s: &str) -> Self {
-        Spec {
+        Self {
             string: Some(s.to_owned()),
             spectype: SpecType::None,
         }
@@ -55,7 +47,7 @@ impl From<&str> for Spec {
 }
 impl From<SpecType> for Spec {
     fn from(t: SpecType) -> Self {
-        Spec {
+        Self {
             string: None,
             spectype: t,
         }

--- a/src/config/lexer.rs
+++ b/src/config/lexer.rs
@@ -87,7 +87,6 @@ fn process_string<I: Iterator<Item = char>>(iter: &mut Peekable<I>, start: char)
                 // Push the character if it exists.
                 ret.push(c);
             }
-            // Unconditionally advance the iterator.
             iter.next();
         } else if !is_ending_char(*peek_char) {
             ret.push(iter.next().unwrap());

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -533,7 +533,7 @@ mod tests {
     fn semicolon_error() {
         fail(
             &toklist!["a"],
-            // Error occurs at EOF.
+            // The error occurs at EOF.
             ParseError::from(ParseErrorType::Expected(&[TokType::Semicolon])),
         );
     }

--- a/src/config/strgen.rs
+++ b/src/config/strgen.rs
@@ -87,7 +87,7 @@ impl<'a> IntoIterator for &'a Spec {
     type Item = String;
     type IntoIter = SpecStrIter<'a>;
     fn into_iter(self) -> Self::IntoIter {
-        SpecStrIter {
+        Self::IntoIter {
             iter: SpecIter::new(self),
         }
     }
@@ -109,7 +109,7 @@ struct SpecIter<'a> {
 }
 impl<'a> SpecIter<'a> {
     pub fn new(spec: &'a Spec) -> Self {
-        let mut ret = SpecIter {
+        let mut ret = Self {
             spec,
             curr_expr: None,
             expr_iter: None,

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use std::{
     error::Error,
     fmt::{self, Display, Formatter},
     io,
-    path::PathBuf,
+    path::{self, PathBuf},
     process,
 };
 
@@ -18,6 +18,7 @@ pub enum AmbitError {
     //       This should be taken care of.
     Parse(config::ParseError),
     WalkDir(walkdir::Error),
+    StripPrefix(path::StripPrefixError),
     // File error is encountered on failed file open operation
     // Provides additional path information
     File {
@@ -48,6 +49,7 @@ impl Display for AmbitError {
             AmbitError::Io(ref e) => e.fmt(f),
             AmbitError::Parse(ref e) => e.fmt(f),
             AmbitError::WalkDir(ref e) => e.fmt(f),
+            AmbitError::StripPrefix(ref e) => e.fmt(f),
             AmbitError::File { path, .. } => {
                 f.write_fmt(format_args!("File error with `{}`", path.display()))
             }
@@ -79,6 +81,12 @@ impl From<io::Error> for AmbitError {
 impl From<walkdir::Error> for AmbitError {
     fn from(err: walkdir::Error) -> AmbitError {
         AmbitError::WalkDir(err)
+    }
+}
+
+impl From<path::StripPrefixError> for AmbitError {
+    fn from(err: path::StripPrefixError) -> AmbitError {
+        AmbitError::StripPrefix(err)
     }
 }
 


### PR DESCRIPTION
This PR implements pattern matching: a feature that permits the use of `*` and `?` to match against files and directories.

This feature requires the `patmatch 0.1.2` crate to facilitate the pattern matching process.

**Implementation details:**

The lexer has been slightly modified to avoid escaping `*` and `?`. The resulting string would then be handled in `cmd.rs` where it is passed to `Pattern::compile` from `patmatch`.

To find matching files and directories, an entry as part of the spec is split into components. For each component, a pattern is compiled and a vector of paths that match this pattern is found. With the vector produced from the previous component, the process is repeated with the ancestor paths equal to the said vector.

Unit tests have been added to test the following:
- The lexer ignores escaping pattern matching characters.
- Paths are correctly derived from a spec.